### PR TITLE
Refactor the Bedrock AI integration to exclusively use the Claude 3.5…

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { streamText, stepCountIs } from 'ai'
-import { model, fastModel, tools, systemPrompt } from '@/lib/ai/bedrock'
+import { model, tools, systemPrompt } from '@/lib/ai/bedrock'
 import { buildFinancialContext } from '@/lib/ai/context'
 import { requireSession } from '@/lib/auth-server'
 import { Currency } from '@prisma/client'
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
     const session = await requireSession()
 
     // Parse request body
-    const { messages, accountId, monthKey, preferredCurrency, useFallback } = await req.json()
+    const { messages, accountId, monthKey, preferredCurrency } = await req.json()
 
     if (!accountId || !monthKey) {
       return new Response('Missing accountId or monthKey', { status: 400 })
@@ -37,15 +37,13 @@ export async function POST(req: Request) {
     // Log tools for debugging
     console.log('Tools config:', JSON.stringify(tools, null, 2))
 
-    // Select model based on explicit fallback flag
-    const selectedModel = useFallback ? fastModel : model
     const result = streamText({
-      model: selectedModel,
+      model,
       system: `${systemPrompt}\n\n=== CURRENT FINANCIAL DATA ===\n${context}`,
       messages: validMessages,
       tools: tools as any,
       stopWhen: stepCountIs(2),
-      maxRetries: useFallback ? 3 : 0,
+      maxRetries: 3,
     })
     return result.toTextStreamResponse()
   } catch (error) {

--- a/src/lib/ai/bedrock.ts
+++ b/src/lib/ai/bedrock.ts
@@ -27,11 +27,9 @@ export const bedrock = createAmazonBedrock({
   }),
 })
 
-// Model configuration - Claude Sonnet 4.5 (September 2025 - most advanced)
-// Using US inference profile for on-demand access
-export const model = bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0')
-// Fallback model for throttling/overflow: Claude 3.5 Sonnet v2
-export const fastModel = bedrock('us.anthropic.claude-3-5-sonnet-20241022-v2:0')
+// Model configuration - Claude 3.5 Sonnet v2
+// This is the primary model for all AI interactions.
+export const model = bedrock('us.anthropic.claude-3-5-sonnet-20241022-v2:0')
 
 // AI Tools - Standard AI SDK format for Bedrock/Claude: array of tool() instances with Zod schemas
 export const tools = [


### PR DESCRIPTION
… Sonnet v2 model.

This change simplifies the model configuration by removing the previous primary model (Claude Sonnet 4.5) and the concept of a `fastModel` fallback. The API route has been updated to remove the `useFallback` logic, ensuring all chat interactions are routed through the single configured model.