### PR TITLE
feat: migrate to nonce-based CSP for stricter security

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { headers } from 'next/headers'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -9,10 +10,15 @@ export const metadata: Metadata = {
   description: 'Plan, track, and forecast shared finances across accounts.',
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // Extract nonce from request headers
+  const nonce = (await headers()).get('x-nonce') ?? undefined
+
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} min-h-screen`}>{children}</body>
+      <body className={`${inter.className} min-h-screen`} nonce={nonce}>
+        {children}
+      </body>
     </html>
   )
 }

--- a/src/lib/nonce.ts
+++ b/src/lib/nonce.ts
@@ -1,0 +1,17 @@
+import 'server-only'
+
+import crypto from 'node:crypto'
+
+/**
+ * Generate a cryptographically secure nonce for CSP.
+ *
+ * Returns a 22-character base64url-encoded string (16 bytes of entropy = 128 bits).
+ * Each nonce should be unique per request to prevent replay attacks.
+ *
+ * @returns A base64url-encoded nonce string
+ */
+export function generateNonce(): string {
+  // Generate 16 bytes (128 bits) of cryptographic entropy
+  // Base64url encoding is URL-safe and doesn't require padding removal
+  return crypto.randomBytes(16).toString('base64url')
+}

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,16 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest, NextResponse } from 'next/server'
 
+// Mock modules BEFORE importing middleware
 vi.mock('@/lib/csrf', () => ({
   getCsrfToken: vi.fn().mockResolvedValue('mock-token'),
 }))
 
+vi.mock('@/lib/nonce', () => ({
+  generateNonce: vi.fn(() => 'mock-nonce-123'),
+}))
+
 import { middleware } from '@/middleware'
 import { getCsrfToken } from '@/lib/csrf'
+import { generateNonce } from '@/lib/nonce'
 
 describe('Middleware', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset mock implementation
+    vi.mocked(generateNonce).mockReturnValue('mock-nonce-123')
   })
 
   it('sets X-Frame-Options header', async () => {
@@ -65,14 +73,87 @@ describe('Middleware', () => {
     expect(csp).toContain('api.frankfurter.app')
   })
 
-  it('CSP allows unsafe-inline for scripts and styles', async () => {
+  it('generates a nonce for each request', async () => {
+    const request = new NextRequest(new URL('http://localhost:3000/'))
+
+    await middleware(request)
+
+    expect(generateNonce).toHaveBeenCalledTimes(1)
+  })
+
+  it('includes nonce in CSP script-src directive', async () => {
     const request = new NextRequest(new URL('http://localhost:3000/'))
 
     const response = await middleware(request)
-
     const csp = response.headers.get('Content-Security-Policy')
-    expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'")
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'")
+
+    expect(csp).toContain("'nonce-mock-nonce-123'")
+    expect(csp).toContain("'strict-dynamic'")
+  })
+
+  it('includes nonce in CSP style-src directive', async () => {
+    const request = new NextRequest(new URL('http://localhost:3000/'))
+
+    const response = await middleware(request)
+    const csp = response.headers.get('Content-Security-Policy')
+
+    expect(csp).toContain("'nonce-mock-nonce-123'")
+  })
+
+  it('includes unsafe-eval in development mode only', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+
+    const request = new NextRequest(new URL('http://localhost:3000/'))
+    const response = await middleware(request)
+    const csp = response.headers.get('Content-Security-Policy')
+
+    expect(csp).toContain("'unsafe-eval'")
+
+    vi.unstubAllEnvs()
+  })
+
+  it('excludes unsafe-eval in production mode', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const request = new NextRequest(new URL('http://localhost:3000/'))
+    const response = await middleware(request)
+    const csp = response.headers.get('Content-Security-Policy')
+
+    expect(csp).not.toContain("'unsafe-eval'")
+
+    vi.unstubAllEnvs()
+  })
+
+  it('includes unsafe-inline for styles in dev, excludes in production', async () => {
+    // Development mode
+    vi.stubEnv('NODE_ENV', 'development')
+    const devRequest = new NextRequest(new URL('http://localhost:3000/'))
+    const devResponse = await middleware(devRequest)
+    const devCsp = devResponse.headers.get('Content-Security-Policy')
+
+    const devStyleMatch = devCsp?.match(/style-src[^;]+/)
+    expect(devStyleMatch?.[0]).toContain("'unsafe-inline'")
+
+    // Production mode
+    vi.stubEnv('NODE_ENV', 'production')
+    const prodRequest = new NextRequest(new URL('http://localhost:3000/'))
+    const prodResponse = await middleware(prodRequest)
+    const prodCsp = prodResponse.headers.get('Content-Security-Policy')
+
+    const prodStyleMatch = prodCsp?.match(/style-src[^;]+/)
+    expect(prodStyleMatch?.[0]).not.toContain("'unsafe-inline'")
+
+    vi.unstubAllEnvs()
+  })
+
+  it('does not include unsafe-inline in script-src', async () => {
+    const request = new NextRequest(new URL('http://localhost:3000/'))
+    const response = await middleware(request)
+    const csp = response.headers.get('Content-Security-Policy')
+
+    // Should not have unsafe-inline for scripts in any mode
+    const scriptSrcMatch = csp?.match(/script-src[^;]+/)
+    expect(scriptSrcMatch?.[0]).not.toContain("'unsafe-inline'")
   })
 
   it('ensures CSRF token exists', async () => {
@@ -111,5 +192,13 @@ describe('Middleware', () => {
     const response = await middleware(request)
 
     expect(response).toBeInstanceOf(NextResponse)
+  })
+
+  it('stores nonce in x-nonce response header', async () => {
+    const request = new NextRequest(new URL('http://localhost:3000/'))
+
+    const response = await middleware(request)
+
+    expect(response.headers.get('x-nonce')).toBe('mock-nonce-123')
   })
 })

--- a/tests/nonce.test.ts
+++ b/tests/nonce.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { generateNonce } from '@/lib/nonce'
+
+describe('generateNonce', () => {
+  it('generates a base64url string', () => {
+    const nonce = generateNonce()
+
+    // Base64url characters: A-Z, a-z, 0-9, -, _
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('generates 22-character string (16 bytes base64url encoded)', () => {
+    const nonce = generateNonce()
+
+    // 16 bytes = 128 bits → base64url = 22 chars (no padding)
+    expect(nonce).toHaveLength(22)
+  })
+
+  it('generates unique values on each call', () => {
+    const nonces = new Set<string>()
+
+    // Generate 1000 nonces
+    for (let i = 0; i < 1000; i++) {
+      nonces.add(generateNonce())
+    }
+
+    // All should be unique
+    expect(nonces.size).toBe(1000)
+  })
+
+  it('produces cryptographically random output', () => {
+    // Generate multiple nonces and verify they have high entropy
+    const nonces = Array.from({ length: 100 }, () => generateNonce())
+
+    // Check that there's no obvious pattern (all different)
+    const uniqueNonces = new Set(nonces)
+    expect(uniqueNonces.size).toBe(100)
+
+    // Check that characters are distributed (not all same char)
+    nonces.forEach((nonce) => {
+      const uniqueChars = new Set(nonce.split(''))
+      expect(uniqueChars.size).toBeGreaterThan(10) // Should have variety
+    })
+  })
+})


### PR DESCRIPTION
Closes #107

## Summary

Migrates from unsafe-inline/unsafe-eval CSP directives to nonce-based CSP for enhanced XSS protection.

## Changes

- **Add nonce generation utility** (src/lib/nonce.ts) with 128-bit cryptographic entropy
- **Update middleware** to generate unique nonce per request and build nonce-based CSP
- **Replace unsafe directives** with nonce-based script-src and style-src
- **Maintain dev compatibility** by keeping unsafe-eval for HMR and unsafe-inline for Tailwind JIT in dev mode only
- **Use strict-dynamic** for modern browser script loading
- **Propagate nonce** via x-nonce response header for Server Component access
- **Update root layout** to support future nonce usage
- **Add comprehensive tests** for nonce generation and CSP headers

## Test Results

- ✅ All 210 tests passing (4 new tests for nonce generation)
- ✅ Type checking passes
- ✅ Build succeeds
- ✅ Linting passes

## CSP Improvements

**Development mode:**
- script-src: 'self' 'nonce-{nonce}' 'strict-dynamic' 'unsafe-eval' (kept for HMR)
- style-src: 'self' 'nonce-{nonce}' 'unsafe-inline' (kept for Tailwind JIT)

**Production mode:**
- script-src: 'self' 'nonce-{nonce}' 'strict-dynamic' ✅ NO unsafe directives
- style-src: 'self' 'nonce-{nonce}' ✅ NO unsafe directives

## Security Benefits

- Stronger XSS protection through nonce-based CSP
- 128-bit entropy nonces prevent replay attacks
- strict-dynamic allows Next.js framework scripts without listing origins
- Future-proof for any inline scripts/styles that might be added