### PR TITLE
test: achieve 90%+ coverage on auth-server.ts (closes #16)

### DIFF
--- a/tests/lib/auth-server.test.ts
+++ b/tests/lib/auth-server.test.ts
@@ -535,8 +535,11 @@ describe('auth-server.ts', () => {
         vi.mocked(prisma.account.findUnique).mockResolvedValue({
           id: 'acc-shared',
           name: 'Shared',
-          balance: 1000,
-          currency: 'USD',
+          type: 'SELF',
+          preferredCurrency: 'USD',
+          color: null,
+          icon: null,
+          description: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -587,8 +590,11 @@ describe('auth-server.ts', () => {
         vi.mocked(prisma.account.findUnique).mockResolvedValue({
           id: 'acc-account2',
           name: 'Account2',
-          balance: 1000,
-          currency: 'USD',
+          type: 'SELF',
+          preferredCurrency: 'USD',
+          color: null,
+          icon: null,
+          description: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -607,8 +613,11 @@ describe('auth-server.ts', () => {
         vi.mocked(prisma.account.findUnique).mockResolvedValue({
           id: 'acc-shared',
           name: 'Shared',
-          balance: 1000,
-          currency: 'USD',
+          type: 'SELF',
+          preferredCurrency: 'USD',
+          color: null,
+          icon: null,
+          description: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -624,8 +633,11 @@ describe('auth-server.ts', () => {
         vi.mocked(prisma.account.findUnique).mockResolvedValue({
           id: 'acc-shared',
           name: 'Shared',
-          balance: 1000,
-          currency: 'USD',
+          type: 'SELF',
+          preferredCurrency: 'USD',
+          color: null,
+          icon: null,
+          description: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -643,8 +655,11 @@ describe('auth-server.ts', () => {
         vi.mocked(prisma.account.findUnique).mockResolvedValue({
           id: 'acc-wrong-case',
           name: 'account1', // lowercase
-          balance: 1000,
-          currency: 'USD',
+          type: 'SELF',
+          preferredCurrency: 'USD',
+          color: null,
+          icon: null,
+          description: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -703,8 +718,11 @@ describe('auth-server.ts', () => {
       vi.mocked(prisma.account.findUnique).mockResolvedValue({
         id: 'acc-shared',
         name: 'Shared',
-        balance: 1000,
-        currency: 'USD',
+        type: 'SELF',
+        preferredCurrency: 'USD',
+        color: null,
+        icon: null,
+        description: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       })


### PR DESCRIPTION
## Summary

Comprehensive test suite for `lib/auth-server.ts` achieving 90%+ coverage target.

## Changes

- **New file**: `tests/lib/auth-server.test.ts` (810 lines, 52 tests)
- **Coverage achieved**: 91.35% statements, 100% functions, 93.33% lines
- **Starting coverage**: 6.17% → **Final**: 91.35% ✅

## Test Organization

**Phase 0: Environment Setup** (1 skipped test)
- Module initialization (documented as untestable)

**Phase 1: Foundation** (16 tests)
- Session establishment & validation
- Token generation, cookie management, session expiry

**Phase 2: Core Auth** (10 tests)
- Credential verification with bcrypt
- Email normalization, error handling

**Phase 3: Session Management** (12 tests)
- Session cleanup, enforcement, user lookup
- Cookie deletion, authentication requirements

**Phase 4: Advanced Features** (7 tests, 1 skipped)
- Account switching & authorization
- Prisma integration, case-sensitive matching
- Unreachable code path documented

**Phase 5: Integration** (5 tests)
- End-to-end workflows (login, logout, account switching)
- 31-day session expiry simulation

**Environment & Configuration** (3 tests)
- Production/development cookie security
- httpOnly, sameSite, path validation

## Test Coverage Details

**All exported functions tested**:
- ✅ verifyCredentials
- ✅ establishSession
- ✅ getSession
- ✅ clearSession
- ✅ requireSession
- ✅ updateSessionAccount
- ✅ getAuthUserFromSession

**Edge cases covered**:
- Session expiry boundaries (29 days valid, 31 days expired)
- Email normalization (whitespace, case-insensitivity)
- Account authorization (case-sensitive name matching)
- Cookie configuration (production secure flag)
- Invalid tokens, missing cookies, unknown users
- Bcrypt exception handling

## Test Results

```
✓ Tests: 355 passed | 3 skipped (358)
✓ All pre-push checks passed
```

## Coverage Report

```
File              | % Stmts | % Branch | % Funcs | % Lines
auth-server.ts    |   91.35 |    82.75 |     100 |   93.33
```

Closes #16