### PR TITLE
feat: add health check endpoint (closes #63)

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -26,16 +26,18 @@ export async function GET() {
 
 async function checkDatabase() {
   const startTime = performance.now()
+  let checkResult
+
   try {
     await prisma.$queryRaw`SELECT 1`
-    const responseTime = Math.round(performance.now() - startTime)
-    return { status: 'up', responseTime }
+    checkResult = { status: 'up' }
   } catch {
-    const responseTime = Math.round(performance.now() - startTime)
-    return {
+    checkResult = {
       status: 'down',
-      responseTime,
       error: 'Database connection failed',
     }
   }
+
+  const responseTime = Math.round(performance.now() - startTime)
+  return { ...checkResult, responseTime }
 }

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -102,18 +102,17 @@ describe('GET /api/health', () => {
   })
 
   describe('Edge cases', () => {
-    it('response time is measured on both success and failure', async () => {
-      // Success case
-      mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }])
-      const successResponse = await GET()
-      const successData = await successResponse.json()
-      expect(successData.checks.database.responseTime).toBeGreaterThanOrEqual(0)
-
-      // Failure case
-      mockQueryRaw.mockRejectedValueOnce(new Error('Connection failed'))
-      const failureResponse = await GET()
-      const failureData = await failureResponse.json()
-      expect(failureData.checks.database.responseTime).toBeGreaterThanOrEqual(0)
+    it.each([
+      { case: 'success', mock: () => mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }]) },
+      {
+        case: 'failure',
+        mock: () => mockQueryRaw.mockRejectedValueOnce(new Error('Connection failed')),
+      },
+    ])('response time is measured on $case', async ({ mock }) => {
+      mock()
+      const response = await GET()
+      const data = await response.json()
+      expect(data.checks.database.responseTime).toBeGreaterThanOrEqual(0)
     })
 
     it('timestamp is valid ISO 8601 format', async () => {


### PR DESCRIPTION
## Summary

- Add `/api/health` GET endpoint for monitoring database connectivity
- Returns 200 (healthy) or 503 (unhealthy) with performance metrics
- Enables Railway and load balancer health checks

## Changes

- **New file:** `src/app/api/health/route.ts` - Health check route handler
  - Database connectivity check via lightweight `SELECT 1` query
  - Response time measurement with `performance.now()`
  - Sanitized error messages (no stack traces or internal details)
  - Returns status, timestamp, checks object, and process uptime
  
- **New file:** `tests/api/health.test.ts` - Comprehensive test suite
  - 10 tests covering success paths, failure paths, and edge cases
  - Mocked Prisma client for fast, isolated tests
  - Validates response format, status codes, and error sanitization

## Testing

- [x] All tests passing (695 total, 10 new)
- [x] Type checking passed
- [x] Linting passed
- [x] Manual testing performed
- [x] Edge cases covered

## Related Issues

Closes #63