### PR TITLE
feat(auth): replace hardcoded AUTH_USERS with database-driven authentication

### DIFF
--- a/src/app/actions/categories.ts
+++ b/src/app/actions/categories.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { successVoid, generalError } from '@/lib/action-result'
 import { handlePrismaError } from '@/lib/prisma-errors'
-import { requireSession, getAuthUserFromSession } from '@/lib/auth-server'
+import { getDbUserAsAuthUser, requireSession } from '@/lib/auth-server'
 import { parseInput, requireCsrfToken } from './shared'
 import { categorySchema, archiveCategorySchema } from '@/schemas'
 
@@ -23,7 +23,7 @@ export async function createCategoryAction(input: z.infer<typeof categorySchema>
     return generalError('Your session expired. Please sign in again.')
   }
 
-  const authUser = getAuthUserFromSession(session)
+  const authUser = await getDbUserAsAuthUser(session.userEmail)
   if (!authUser) {
     return generalError('User record not found')
   }
@@ -65,7 +65,7 @@ export async function archiveCategoryAction(input: z.infer<typeof archiveCategor
     return generalError('Your session expired. Please sign in again.')
   }
 
-  const authUser = getAuthUserFromSession(session)
+  const authUser = await getDbUserAsAuthUser(session.userEmail)
   if (!authUser) {
     return generalError('User record not found')
   }

--- a/src/app/actions/shared.ts
+++ b/src/app/actions/shared.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import type { AuthUser } from '@/lib/auth'
-import { getAuthUserFromSession, getDbUserAsAuthUser, requireSession } from '@/lib/auth-server'
+import { getDbUserAsAuthUser, requireSession } from '@/lib/auth-server'
 import { validateCsrfToken } from '@/lib/csrf'
 
 // Currency precision: 2 decimal places (cents), scale factor 100
@@ -47,13 +47,8 @@ export async function requireAuthUser(): Promise<AuthUserResult> {
     return { error: { general: ['Your session expired. Please sign in again.'] } }
   }
 
-  // First check legacy AUTH_USERS
-  let authUser = getAuthUserFromSession(session)
-
-  // If not found, check database users
-  if (!authUser) {
-    authUser = await getDbUserAsAuthUser(session.userEmail)
-  }
+  // Get user from database
+  const authUser = await getDbUserAsAuthUser(session.userEmail)
 
   if (!authUser) {
     return { error: { general: ['We could not resolve your user profile. Please sign in again.'] } }

--- a/src/app/api/v1/budgets/route.ts
+++ b/src/app/api/v1/budgets/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: NextRequest) {
     return forbiddenError('Account not found')
   }
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }
@@ -114,7 +114,7 @@ export async function DELETE(request: NextRequest) {
     return forbiddenError('Account not found')
   }
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/holdings/[id]/route.ts
+++ b/src/app/api/v1/holdings/[id]/route.ts
@@ -59,7 +59,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const account = await prisma.account.findUnique({ where: { id: existing.accountId } })
   if (!account) return notFoundError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }
@@ -101,7 +101,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const account = await prisma.account.findUnique({ where: { id: existing.accountId } })
   if (!account) return notFoundError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/holdings/refresh/route.ts
+++ b/src/app/api/v1/holdings/refresh/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
   const account = await prisma.account.findUnique({ where: { id: data.accountId } })
   if (!account) return forbiddenError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/holdings/route.ts
+++ b/src/app/api/v1/holdings/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: NextRequest) {
   const account = await prisma.account.findUnique({ where: { id: data.accountId } })
   if (!account) return forbiddenError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/recurring/[id]/toggle/route.ts
+++ b/src/app/api/v1/recurring/[id]/toggle/route.ts
@@ -59,7 +59,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   const account = await prisma.account.findUnique({ where: { id: existing.accountId } })
   if (!account) return notFoundError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/recurring/apply/route.ts
+++ b/src/app/api/v1/recurring/apply/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
   const account = await prisma.account.findUnique({ where: { id: data.accountId } })
   if (!account) return forbiddenError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/recurring/route.ts
+++ b/src/app/api/v1/recurring/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
   const account = await prisma.account.findUnique({ where: { id: data.accountId } })
   if (!account) return forbiddenError('Account not found')
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/api/v1/transactions/[id]/route.ts
+++ b/src/app/api/v1/transactions/[id]/route.ts
@@ -59,7 +59,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const existingAccount = await prisma.account.findUnique({
     where: { id: existing.accountId },
   })
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
 
   if (!existingAccount || !authUser.accountNames.includes(existingAccount.name)) {
     return forbiddenError('You do not have access to this transaction')
@@ -112,7 +112,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const account = await prisma.account.findUnique({
     where: { id: existing.accountId },
   })
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
 
   if (!account || !authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this transaction')

--- a/src/app/api/v1/transactions/requests/[id]/approve/route.ts
+++ b/src/app/api/v1/transactions/requests/[id]/approve/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const toAccount = await prisma.account.findUnique({
     where: { id: transactionRequest.toId },
   })
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
 
   if (!toAccount || !authUser.accountNames.includes(toAccount.name)) {
     return forbiddenError('You do not have access to this transaction request')

--- a/src/app/api/v1/transactions/requests/[id]/reject/route.ts
+++ b/src/app/api/v1/transactions/requests/[id]/reject/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const toAccount = await prisma.account.findUnique({
     where: { id: transactionRequest.toId },
   })
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
 
   if (!toAccount || !authUser.accountNames.includes(toAccount.name)) {
     return forbiddenError('You do not have access to this transaction request')

--- a/src/app/api/v1/transactions/requests/route.ts
+++ b/src/app/api/v1/transactions/requests/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
   const data = parsed.data
 
   // 3. Get user's primary account (the 'from' account)
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   const fromAccount = await getUserPrimaryAccount(authUser.accountNames)
 
   if (!fromAccount) {

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
     return forbiddenError('Account not found')
   }
 
-  const authUser = getUserAuthInfo(user.userId)
+  const authUser = await getUserAuthInfo(user.userId)
   if (!authUser.accountNames.includes(account.name)) {
     return forbiddenError('You do not have access to this account')
   }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { LoginCard } from '@/components/auth/login-card'
-import { AUTH_USERS } from '@/lib/auth'
 import { getAccounts } from '@/lib/finance'
-import { getSession } from '@/lib/auth-server'
+import { getSession, getDbUserAsAuthUser } from '@/lib/auth-server'
 
 export const metadata: Metadata = {
   title: 'Sign in · Balance Beacon',
@@ -15,25 +14,26 @@ type LoginPageProps = {
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
-  'no-accounts': 'No accounts were found for this login. Seed the Avi and Serena accounts, then sign in again.',
-  'account-access': 'You tried to open an account that is not assigned to your login. Pick one of your personal or partner accounts.',
+  'no-accounts': 'No accounts were found for this login. Please contact support.',
+  'account-access': 'You tried to open an account that is not assigned to your login. Pick one of your accounts.',
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : {}
   const reasonParam = resolvedSearchParams.reason
   const reason = Array.isArray(reasonParam) ? reasonParam[0] : reasonParam
-  const reasonMessage = reason ? ERROR_MESSAGES[reason] ?? 'Please sign in to continue.' : undefined
+  const reasonMessage = reason ? (ERROR_MESSAGES[reason] ?? 'Please sign in to continue.') : undefined
 
   const session = await getSession()
   const accounts = await getAccounts()
 
   if (session) {
-    const authUser = AUTH_USERS.find((user) => user.email.toLowerCase() === session.userEmail.toLowerCase())
+    const authUser = await getDbUserAsAuthUser(session.userEmail)
     if (authUser) {
       const allowedAccounts = accounts.filter((account) => authUser.accountNames.includes(account.name))
       if (allowedAccounts.length > 0) {
-        const fallbackAccount = allowedAccounts.find((account) => account.id === session.accountId)?.id ?? allowedAccounts[0].id
+        const fallbackAccount =
+          allowedAccounts.find((account) => account.id === session.accountId)?.id ?? allowedAccounts[0].id
         redirect(`/?account=${fallbackAccount}`)
       }
     }
@@ -45,7 +45,10 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
         className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(94,234,212,0.18),_transparent_55%),_linear-gradient(145deg,_#020617_0%,_#0f172a_55%,_#020617_100%)]"
         aria-hidden
       />
-      <div className="absolute inset-y-0 right-0 -z-10 hidden w-[45%] bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_transparent_60%)] blur-3xl lg:block" aria-hidden />
+      <div
+        className="absolute inset-y-0 right-0 -z-10 hidden w-[45%] bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_transparent_60%)] blur-3xl lg:block"
+        aria-hidden
+      />
 
       <div className="relative grid w-full max-w-6xl gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
         <section className="space-y-8 rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-lg lg:p-12">
@@ -57,7 +60,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
               Plan confidently, one account at a time
             </h1>
             <p className="max-w-xl text-base text-slate-200/80">
-              Sign in with your personal credentials to focus on your household accounts and shared plans without overlap.
+              Sign in with your credentials to manage your personal finances and track your expenses.
             </p>
           </div>
 
@@ -69,8 +72,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
             )}
             <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
               <p>
-                Keep your personal password manager in sync after any reset. A confirmation email outlines the process and reiterates
-                the canonical secrets so both partners stay aligned.
+                Keep your personal password manager in sync after any reset. A confirmation email outlines the process.
               </p>
             </div>
           </dl>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,7 @@ import { DashboardSkeleton } from '@/components/ui/skeleton'
 import { getAccounts } from '@/lib/finance'
 import { getCachedDashboardData } from '@/lib/dashboard-cache'
 import { getMonthKey } from '@/utils/date'
-import { getSession, updateSessionAccount } from '@/lib/auth-server'
-import { AUTH_USERS } from '@/lib/auth'
+import { getSession, updateSessionAccount, getDbUserAsAuthUser } from '@/lib/auth-server'
 
 export const dynamic = 'force-dynamic'
 
@@ -43,11 +42,10 @@ export default async function Page({ searchParams }: PageProps) {
     redirect('/login')
   }
 
-  const authUserRecord = AUTH_USERS.find((user) => user.email.toLowerCase() === session.userEmail.toLowerCase())
-  if (!authUserRecord) {
+  const authUser = await getDbUserAsAuthUser(session.userEmail)
+  if (!authUser) {
     redirect('/login?reason=unknown-user')
   }
-  const authUser = authUserRecord
 
   const currentMonth = getMonthKey(new Date())
   const resolvedSearchParams = searchParams ? await searchParams : {}

--- a/src/components/auth/login-card.tsx
+++ b/src/components/auth/login-card.tsx
@@ -67,7 +67,7 @@ export function LoginCard() {
         return
       }
       form.reset()
-      setStatusMessage(result.message ?? 'Reset instructions were sent to your inbox.')
+      setStatusMessage(result.data.message ?? 'Reset instructions were sent to your inbox.')
     })
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,9 @@
 import { Currency } from '@prisma/client'
 
+/**
+ * AuthUser represents an authenticated user with their account information.
+ * This type is used throughout the app for session and authorization checks.
+ */
 export type AuthUser = {
   id: string
   email: string
@@ -10,88 +14,7 @@ export type AuthUser = {
   preferredCurrency: Currency
 }
 
-function parseAuthUsers(): AuthUser[] {
-  const user1Email = process.env.AUTH_USER1_EMAIL?.trim()
-  const user1DisplayName = process.env.AUTH_USER1_DISPLAY_NAME?.trim()
-  // Strip quotes, whitespace, and unescape \$ that might be added by environment variable storage
-  const user1PasswordHashRaw = process.env.AUTH_USER1_PASSWORD_HASH?.trim().replace(/^["']|["']$/g, '')
-  const user1PasswordHash = user1PasswordHashRaw?.replace(/\\\$/g, '$') // Unescape \$ -> $
-  const user1PreferredCurrency = (process.env.AUTH_USER1_PREFERRED_CURRENCY as Currency) || Currency.USD
-
-  const user2Email = process.env.AUTH_USER2_EMAIL?.trim()
-  const user2DisplayName = process.env.AUTH_USER2_DISPLAY_NAME?.trim()
-  // Strip quotes, whitespace, and unescape \$ that might be added by environment variable storage
-  const user2PasswordHashRaw = process.env.AUTH_USER2_PASSWORD_HASH?.trim().replace(/^["']|["']$/g, '')
-  const user2PasswordHash = user2PasswordHashRaw?.replace(/\\\$/g, '$') // Unescape \$ -> $
-  const user2PreferredCurrency = (process.env.AUTH_USER2_PREFERRED_CURRENCY as Currency) || Currency.USD
-
-  if (!user1Email || !user1DisplayName || !user1PasswordHash) {
-    throw new Error('Missing required environment variables for user 1 (AUTH_USER1_*)')
-  }
-
-  if (!user2Email || !user2DisplayName || !user2PasswordHash) {
-    throw new Error('Missing required environment variables for user 2 (AUTH_USER2_*)')
-  }
-
-  return [
-    {
-      id: 'avi',
-      email: user1Email,
-      displayName: user1DisplayName,
-      passwordHash: user1PasswordHash,
-      accountNames: ['Avi'],
-      defaultAccountName: 'Avi',
-      preferredCurrency: user1PreferredCurrency,
-    },
-    {
-      id: 'serena',
-      email: user2Email,
-      displayName: user2DisplayName,
-      passwordHash: user2PasswordHash,
-      accountNames: ['Serena'],
-      defaultAccountName: 'Serena',
-      preferredCurrency: user2PreferredCurrency,
-    },
-  ]
-}
-
-let _authUsers: AuthUser[] | null = null
-
-export function getAuthUsers(): AuthUser[] {
-  if (!_authUsers) {
-    _authUsers = parseAuthUsers()
-  }
-  return _authUsers
-}
-
-// For backward compatibility
-export const AUTH_USERS = new Proxy({} as AuthUser[], {
-  get(_target, prop) {
-    const users = getAuthUsers()
-    return users[prop as keyof typeof users]
-  },
-  has(_target, prop) {
-    return prop in getAuthUsers()
-  },
-  ownKeys(_target) {
-    return Reflect.ownKeys(getAuthUsers())
-  },
-}) as unknown as AuthUser[]
-
-export function getRecoveryContacts() {
-  return getAuthUsers().map((user) => ({
-    email: user.email,
-    label: `${user.displayName} recovery inbox`,
-  }))
-}
-
-export const RECOVERY_CONTACTS = new Proxy([] as ReturnType<typeof getRecoveryContacts>, {
-  get(_target, prop) {
-    const contacts = getRecoveryContacts()
-    return contacts[prop as keyof typeof contacts]
-  },
-}) as unknown as ReturnType<typeof getRecoveryContacts>
-
+// Session cookie names
 export const SESSION_COOKIE = 'balance_session'
 export const USER_COOKIE = 'balance_user'
 export const ACCOUNT_COOKIE = 'balance_account'

--- a/tests/api/v1/transactions.test.ts
+++ b/tests/api/v1/transactions.test.ts
@@ -22,6 +22,20 @@ describe('Transaction API Routes', () => {
     // Get test user for userId foreign keys
     const testUser = await getApiTestUser()
 
+    // Create 'serena' user for transaction request approval tests
+    // This user owns the 'other' account and can approve/reject requests
+    const serenaUser = await prisma.user.upsert({
+      where: { id: 'serena' },
+      update: {},
+      create: {
+        id: 'serena',
+        email: 'serena@example.com',
+        displayName: 'Serena Test User',
+        passwordHash: '$2b$10$placeholder',
+        preferredCurrency: 'USD',
+      },
+    })
+
     // Upsert test accounts and category (atomic, no race condition)
     const account = await prisma.account.upsert({
       where: { userId_name: { userId: testUser.id, name: 'Avi' } },
@@ -29,10 +43,11 @@ describe('Transaction API Routes', () => {
       create: { userId: testUser.id, name: 'Avi', type: 'SELF' },
     })
 
+    // Other account belongs to 'serena' user - for request approval tests
     const otherAccount = await prisma.account.upsert({
-      where: { userId_name: { userId: testUser.id, name: 'Serena' } },
+      where: { userId_name: { userId: serenaUser.id, name: 'SerenaAccount' } },
       update: {},
-      create: { userId: testUser.id, name: 'Serena', type: 'SELF' },
+      create: { userId: serenaUser.id, name: 'SerenaAccount', type: 'SELF' },
     })
 
     const category = await prisma.category.upsert({

--- a/tests/budget-actions.test.ts
+++ b/tests/budget-actions.test.ts
@@ -10,7 +10,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn(),
-  getAuthUserFromSession: vi.fn(),
+  getDbUserAsAuthUser: vi.fn(),
 }))
 
 vi.mock('@/lib/csrf', () => ({
@@ -81,9 +81,9 @@ describe('upsertBudgetAction', () => {
   })
 
   it('should fail when user does not have access to account', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -116,9 +116,9 @@ describe('upsertBudgetAction', () => {
   })
 
   it('should successfully create a new budget', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -178,9 +178,9 @@ describe('upsertBudgetAction', () => {
   })
 
   it('should handle budget update', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -236,9 +236,9 @@ describe('deleteBudgetAction', () => {
   })
 
   it('should successfully delete a budget', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -276,9 +276,9 @@ describe('deleteBudgetAction', () => {
   })
 
   it('should handle database error gracefully', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',

--- a/tests/category-actions.test.ts
+++ b/tests/category-actions.test.ts
@@ -15,9 +15,9 @@ vi.mock('@/lib/csrf', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({ userEmail: 'test@example.com', accountId: 'acc-1' }),
-  getAuthUserFromSession: vi
+  getDbUserAsAuthUser: vi
     .fn()
-    .mockReturnValue({ id: 'test-user', email: 'test@example.com', accountNames: ['TestAccount'] }),
+    .mockResolvedValue({ id: 'test-user', email: 'test@example.com', accountNames: ['TestAccount'] }),
 }))
 
 vi.mock('@prisma/client', async (importOriginal) => {

--- a/tests/holdings-actions.test.ts
+++ b/tests/holdings-actions.test.ts
@@ -15,7 +15,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn(),
-  getAuthUserFromSession: vi.fn(),
+  getDbUserAsAuthUser: vi.fn(),
 }))
 
 vi.mock('@prisma/client', async (importOriginal) => {
@@ -80,9 +80,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should successfully create a holding', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -124,9 +124,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should fail when category is not a holding category', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -167,9 +167,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should fail with invalid stock symbol', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -211,9 +211,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should convert symbol to uppercase', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -290,9 +290,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should fail when category not found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -328,9 +328,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should fail when category lookup throws database error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -366,9 +366,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should handle non-Error stock API failures', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -410,9 +410,9 @@ describe('createHoldingAction', () => {
   })
 
   it('should fail when database cannot create holding', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -462,9 +462,9 @@ describe('updateHoldingAction', () => {
   })
 
   it('should successfully update a holding', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -500,9 +500,9 @@ describe('updateHoldingAction', () => {
   })
 
   it('should fail when holding not found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -529,9 +529,9 @@ describe('updateHoldingAction', () => {
   })
 
   it('should fail when user lacks access to holding account', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -567,9 +567,9 @@ describe('updateHoldingAction', () => {
   })
 
   it('should fail when database update throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -613,9 +613,9 @@ describe('deleteHoldingAction', () => {
   })
 
   it('should successfully delete a holding', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -647,9 +647,9 @@ describe('deleteHoldingAction', () => {
   })
 
   it('should fail when database delete throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -687,9 +687,9 @@ describe('refreshHoldingPricesAction', () => {
   })
 
   it('should successfully refresh prices for all holdings', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -727,9 +727,9 @@ describe('refreshHoldingPricesAction', () => {
   })
 
   it('should return zero when no holdings found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -757,9 +757,9 @@ describe('refreshHoldingPricesAction', () => {
   })
 
   it('should handle duplicate symbols', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -795,9 +795,9 @@ describe('refreshHoldingPricesAction', () => {
   })
 
   it('should fail when user lacks account access', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -822,9 +822,9 @@ describe('refreshHoldingPricesAction', () => {
   })
 
   it('should fail when database throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',

--- a/tests/integration/account-switching-flow.test.ts
+++ b/tests/integration/account-switching-flow.test.ts
@@ -9,15 +9,20 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-// Mock auth to return user with access to both accounts
+// Mock auth to return user with access to both accounts (database-driven)
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({
-    user: { username: 'testuser', email: 'test@example.com' },
+    userEmail: 'test@example.com',
+    accountId: 'test-account-id',
   }),
-  getAuthUserFromSession: vi.fn().mockReturnValue({
-    username: 'testuser',
+  getDbUserAsAuthUser: vi.fn().mockResolvedValue({
+    id: 'test-user-id',
     email: 'test@example.com',
+    displayName: 'Test User',
+    passwordHash: 'hash',
     accountNames: ['TEST_Account_A', 'TEST_Account_B'],
+    defaultAccountName: 'TEST_Account_A',
+    preferredCurrency: 'USD',
   }),
 }))
 

--- a/tests/integration/budget-flow.test.ts
+++ b/tests/integration/budget-flow.test.ts
@@ -10,15 +10,20 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-// Mock auth to return test user
+// Mock auth to return test user (database-driven)
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({
-    user: { username: 'testuser', email: 'test@example.com' },
+    userEmail: 'test@example.com',
+    accountId: 'test-account-id',
   }),
-  getAuthUserFromSession: vi.fn().mockReturnValue({
-    username: 'testuser',
+  getDbUserAsAuthUser: vi.fn().mockResolvedValue({
+    id: 'test-user-id',
     email: 'test@example.com',
+    displayName: 'Test User',
+    passwordHash: 'hash',
     accountNames: ['TEST_Budget_Account'],
+    defaultAccountName: 'TEST_Budget_Account',
+    preferredCurrency: 'USD',
   }),
 }))
 

--- a/tests/integration/holdings-flow.test.ts
+++ b/tests/integration/holdings-flow.test.ts
@@ -9,15 +9,20 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-// Mock auth to return test user
+// Mock auth to return test user (database-driven)
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({
-    user: { username: 'testuser', email: 'test@example.com' },
+    userEmail: 'test@example.com',
+    accountId: 'test-account-id',
   }),
-  getAuthUserFromSession: vi.fn().mockReturnValue({
-    username: 'testuser',
+  getDbUserAsAuthUser: vi.fn().mockResolvedValue({
+    id: 'test-user-id',
     email: 'test@example.com',
+    displayName: 'Test User',
+    passwordHash: 'hash',
     accountNames: ['TEST_Holdings_Account'],
+    defaultAccountName: 'TEST_Holdings_Account',
+    preferredCurrency: 'USD',
   }),
 }))
 

--- a/tests/integration/recurring-flow.test.ts
+++ b/tests/integration/recurring-flow.test.ts
@@ -13,15 +13,20 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-// Mock auth to return test user
+// Mock auth to return test user (database-driven)
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({
-    user: { username: 'testuser', email: 'test@example.com' },
+    userEmail: 'test@example.com',
+    accountId: 'test-account-id',
   }),
-  getAuthUserFromSession: vi.fn().mockReturnValue({
-    username: 'testuser',
+  getDbUserAsAuthUser: vi.fn().mockResolvedValue({
+    id: 'test-user-id',
     email: 'test@example.com',
+    displayName: 'Test User',
+    passwordHash: 'hash',
     accountNames: ['TEST_Recurring_Account'],
+    defaultAccountName: 'TEST_Recurring_Account',
+    preferredCurrency: 'USD',
   }),
 }))
 

--- a/tests/integration/transaction-flow.test.ts
+++ b/tests/integration/transaction-flow.test.ts
@@ -9,15 +9,20 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-// Mock auth to return test user
+// Mock auth to return test user (database-driven)
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({
-    user: { username: 'testuser', email: 'test@example.com' },
+    userEmail: 'test@example.com',
+    accountId: 'test-account-id',
   }),
-  getAuthUserFromSession: vi.fn().mockReturnValue({
-    username: 'testuser',
+  getDbUserAsAuthUser: vi.fn().mockResolvedValue({
+    id: 'test-user-id',
     email: 'test@example.com',
+    displayName: 'Test User',
+    passwordHash: 'hash',
     accountNames: ['TEST_Account'],
+    defaultAccountName: 'TEST_Account',
+    preferredCurrency: 'USD',
   }),
 }))
 

--- a/tests/misc-actions.test.ts
+++ b/tests/misc-actions.test.ts
@@ -10,7 +10,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn(),
-  getAuthUserFromSession: vi.fn(),
+  getDbUserAsAuthUser: vi.fn(),
 }))
 
 vi.mock('@prisma/client', async (importOriginal) => {
@@ -172,9 +172,9 @@ describe('setBalanceAction', () => {
   })
 
   it('should create positive adjustment when target is higher', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -227,9 +227,9 @@ describe('setBalanceAction', () => {
   })
 
   it('should create negative adjustment when target is lower', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -282,9 +282,9 @@ describe('setBalanceAction', () => {
   })
 
   it('should skip adjustment when balance is already correct', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -323,9 +323,9 @@ describe('setBalanceAction', () => {
   })
 
   it('should create Balance Adjustment category if not exists', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -371,9 +371,9 @@ describe('setBalanceAction', () => {
   })
 
   it('should handle decimal amounts properly', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -431,9 +431,9 @@ describe('setBalanceAction', () => {
   })
 
   it('should handle negative target balance', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',

--- a/tests/recurring-actions.test.ts
+++ b/tests/recurring-actions.test.ts
@@ -14,7 +14,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn(),
-  getAuthUserFromSession: vi.fn(),
+  getDbUserAsAuthUser: vi.fn(),
 }))
 
 vi.mock('@prisma/client', async (importOriginal) => {
@@ -75,9 +75,9 @@ describe('upsertRecurringTemplateAction', () => {
   })
 
   it('should successfully create a new recurring template', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -114,9 +114,9 @@ describe('upsertRecurringTemplateAction', () => {
   })
 
   it('should successfully update an existing template', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -217,9 +217,9 @@ describe('upsertRecurringTemplateAction', () => {
   })
 
   it('should accept end month equal to start month', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -261,9 +261,9 @@ describe('toggleRecurringTemplateAction', () => {
   })
 
   it('should successfully toggle template to inactive', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -301,9 +301,9 @@ describe('toggleRecurringTemplateAction', () => {
   })
 
   it('should fail when template not found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -334,9 +334,9 @@ describe('applyRecurringTemplatesAction', () => {
   })
 
   it('should create transactions from active templates', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -382,9 +382,9 @@ describe('applyRecurringTemplatesAction', () => {
   })
 
   it('should skip templates that already have transactions', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -434,9 +434,9 @@ describe('applyRecurringTemplatesAction', () => {
   })
 
   it('should handle day 31 in months with fewer days', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -480,9 +480,9 @@ describe('applyRecurringTemplatesAction', () => {
   })
 
   it('should return zero when no templates found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -513,9 +513,9 @@ describe('applyRecurringTemplatesAction', () => {
   })
 
   it('should apply only specified template IDs', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',

--- a/tests/registration.test.ts
+++ b/tests/registration.test.ts
@@ -380,7 +380,6 @@ describe('verifyCredentials with database users', () => {
 
     expect(result.valid).toBe(true)
     if (result.valid) {
-      expect(result.source).toBe('database')
       expect(result.userId).toBe('db-user-1')
     }
   })

--- a/tests/security/xss.test.ts
+++ b/tests/security/xss.test.ts
@@ -6,21 +6,21 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-// Mock auth-server - must be at top
+// Mock auth-server - must be at top (database-driven)
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn().mockResolvedValue({
     userEmail: 'test@example.com',
     accountId: 'test-account-id',
   }),
-  getAuthUserFromSession: vi.fn().mockReturnValue({
+  getDbUserAsAuthUser: vi.fn().mockResolvedValue({
     id: 'test-user',
     email: 'test@example.com',
     displayName: 'Test User',
+    passwordHash: 'hash',
     accountNames: ['Test Account'],
     defaultAccountName: 'Test Account',
     preferredCurrency: 'USD',
   }),
-  getDbUserAsAuthUser: vi.fn().mockResolvedValue(null),
 }))
 
 // Mock CSRF validation - must be at top

--- a/tests/transaction-crud-actions.test.ts
+++ b/tests/transaction-crud-actions.test.ts
@@ -10,7 +10,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn(),
-  getAuthUserFromSession: vi.fn(),
+  getDbUserAsAuthUser: vi.fn(),
 }))
 
 vi.mock('@/lib/csrf', () => ({
@@ -90,9 +90,9 @@ describe('createTransactionAction', () => {
   })
 
   it('should successfully create an expense transaction', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -128,9 +128,9 @@ describe('createTransactionAction', () => {
   })
 
   it('should successfully create an income transaction', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -185,9 +185,9 @@ describe('createTransactionAction', () => {
   })
 
   it('should accept null description', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -222,9 +222,9 @@ describe('createTransactionAction', () => {
   })
 
   it('should create recurring transaction', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -259,9 +259,9 @@ describe('createTransactionAction', () => {
   })
 
   it('should fail when database create throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -305,9 +305,9 @@ describe('updateTransactionAction', () => {
   })
 
   it('should fail when transaction not found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -340,9 +340,9 @@ describe('updateTransactionAction', () => {
   })
 
   it('should successfully update transaction', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -385,9 +385,9 @@ describe('updateTransactionAction', () => {
   })
 
   it('should handle account change', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -435,9 +435,9 @@ describe('updateTransactionAction', () => {
   })
 
   it('should fail when user lacks access to existing transaction account', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -479,9 +479,9 @@ describe('updateTransactionAction', () => {
   })
 
   it('should fail when changing to unauthorized account', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -530,9 +530,9 @@ describe('updateTransactionAction', () => {
   })
 
   it('should fail when database update throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -583,9 +583,9 @@ describe('deleteTransactionAction', () => {
   })
 
   it('should fail when transaction not found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -606,9 +606,9 @@ describe('deleteTransactionAction', () => {
   })
 
   it('should successfully delete transaction', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -641,9 +641,9 @@ describe('deleteTransactionAction', () => {
   })
 
   it('should fail when user lacks access to transaction account', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -673,9 +673,9 @@ describe('deleteTransactionAction', () => {
   })
 
   it('should fail when database delete throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',
@@ -708,9 +708,9 @@ describe('deleteTransactionAction', () => {
   })
 
   it('should fail when database findUnique throws error', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'test@example.com',
       id: 'avi',
       displayName: 'Test User',

--- a/tests/transaction-request-actions.test.ts
+++ b/tests/transaction-request-actions.test.ts
@@ -14,7 +14,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('@/lib/auth-server', () => ({
   requireSession: vi.fn(),
-  getAuthUserFromSession: vi.fn(),
+  getDbUserAsAuthUser: vi.fn(),
 }))
 
 vi.mock('@prisma/client', async (importOriginal) => {
@@ -97,9 +97,9 @@ describe('createTransactionRequestAction', () => {
   })
 
   it('successfully creates a request', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'avi@example.com',
       id: 'avi',
       displayName: 'Avi',
@@ -144,9 +144,9 @@ describe('approveTransactionRequestAction', () => {
   })
 
   it('fails if the request is not found', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'serena@example.com',
       id: 'serena',
       displayName: 'Serena',
@@ -164,9 +164,9 @@ describe('approveTransactionRequestAction', () => {
   })
 
   it('successfully approves a request and creates a transaction', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'serena@example.com',
       id: 'serena',
       displayName: 'Serena',
@@ -214,9 +214,9 @@ describe('rejectTransactionRequestAction', () => {
   })
 
   it('successfully rejects a request', async () => {
-    const { requireSession, getAuthUserFromSession } = await import('@/lib/auth-server')
+    const { requireSession, getDbUserAsAuthUser } = await import('@/lib/auth-server')
     vi.mocked(requireSession).mockResolvedValue({} as any)
-    vi.mocked(getAuthUserFromSession).mockReturnValue({
+    vi.mocked(getDbUserAsAuthUser).mockResolvedValue({
       email: 'serena@example.com',
       id: 'serena',
       displayName: 'Serena',


### PR DESCRIPTION
## Summary
- Remove AUTH_USERS and RECOVERY_CONTACTS arrays from auth.ts
- Remove getAuthUsers() and env var parsing (AUTH_USER1_*, AUTH_USER2_*)
- Add getDbUserAsAuthUser() to query users from database with accounts
- Update getUserAuthInfo() in api-auth.ts to query database by userId
- Update all API routes to await getUserAuthInfo() (now async)
- Update login and password reset to use database lookups

## Test Plan
- All 900 existing tests pass
- Login flow tested with database users
- Authorization properly checks user's accounts from database

## Related Issues
Closes #32