### PR TITLE
feat(mobile): add biometric authentication for quick login (#80)

### DIFF
--- a/.claude/tasks.json
+++ b/.claude/tasks.json
@@ -58,9 +58,45 @@
       "claimedAt": "2026-01-16T23:30:00Z",
       "branch": "feature/legal-pages-155",
       "worktreePath": "C:/Users/avife/expense-track-legal-pages-155",
-      "labels": ["infrastructure"],
+      "labels": [
+        "infrastructure"
+      ],
       "url": "https://github.com/avifenesh/expense-track/issues/155"
     }
   ],
-  "lastUpdated": "2026-01-17T00:15:00Z"
+  "lastUpdated": "2026-01-17T00:30:00Z",
+  "tasks": [
+    {
+      "id": "71",
+      "source": "github",
+      "title": "Implement secure token storage on mobile",
+      "description": "Use SecureStore/Keychain for storing access tokens, refresh tokens, and handling token expiry",
+      "labels": [
+        "mobile",
+        "security"
+      ],
+      "milestone": "Sprint 3: Mobile App",
+      "branch": "feature/secure-token-storage-71",
+      "worktreePath": "C:\\Users\\avife\\worktrees\\expense-track-secure-token-71",
+      "claimedAt": "2026-01-17T00:00:34.610Z",
+      "status": "claimed",
+      "lastActivityAt": "2026-01-17T00:00:34.611Z"
+    },
+    {
+      "id": "137",
+      "source": "github-issue",
+      "title": "Integrate payment provider for subscriptions",
+      "description": "Set up payment provider integration for handling subscription billing and payments",
+      "labels": [
+        "subscription",
+        "infrastructure"
+      ],
+      "branch": "feature/payment-provider-137",
+      "worktreePath": "C:/Users/avife/worktrees/payment-provider-137",
+      "claimedAt": "2026-01-17T00:30:00Z",
+      "status": "claimed",
+      "lastActivityAt": "2026-01-17T00:30:00Z",
+      "url": "https://github.com/avifenesh/expense-track/issues/137"
+    }
+  ]
 }

--- a/mobile/__tests__/screens/auth/LoginScreen.test.tsx
+++ b/mobile/__tests__/screens/auth/LoginScreen.test.tsx
@@ -5,11 +5,14 @@ import { LoginScreen } from '../../../src/screens/auth/LoginScreen';
 import { AuthProvider } from '../../../src/contexts';
 import { ApiError } from '../../../src/services/api';
 import * as authService from '../../../src/services/auth';
+import * as biometricService from '../../../src/services/biometric';
 import type { AuthScreenProps } from '../../../src/navigation/types';
 
 jest.mock('../../../src/services/auth');
+jest.mock('../../../src/services/biometric');
 
 const mockAuthService = authService as jest.Mocked<typeof authService>;
+const mockBiometricService = biometricService as jest.Mocked<typeof biometricService>;
 
 const mockNavigate = jest.fn();
 const mockNavigation = {
@@ -39,36 +42,53 @@ const renderLoginScreen = () => {
 describe('LoginScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default biometric mocks
+    mockBiometricService.checkBiometricCapability.mockResolvedValue({
+      isAvailable: false,
+      biometricType: 'none',
+      isEnrolled: false,
+    });
+    mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
   });
 
   describe('Rendering', () => {
-    it('renders login form with email and password inputs', () => {
+    it('renders login form with email and password inputs', async () => {
       renderLoginScreen();
 
-      expect(screen.getByText('Sign In')).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByText('Sign In')).toBeTruthy();
+      });
       expect(screen.getByText('Welcome back to Balance Beacon')).toBeTruthy();
       expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
       expect(screen.getByPlaceholderText('Enter your password')).toBeTruthy();
     });
 
-    it('renders navigation links', () => {
+    it('renders navigation links', async () => {
       renderLoginScreen();
 
-      expect(screen.getByText(/Don't have an account/)).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByText(/Don't have an account/)).toBeTruthy();
+      });
       expect(screen.getByText(/Forgot password/)).toBeTruthy();
     });
 
-    it('renders Sign In button', () => {
+    it('renders Sign In button', async () => {
       renderLoginScreen();
 
-      const buttons = screen.getAllByText('Sign In');
-      expect(buttons.length).toBeGreaterThan(0);
+      await waitFor(() => {
+        const buttons = screen.getAllByText('Sign In');
+        expect(buttons.length).toBeGreaterThan(0);
+      });
     });
   });
 
   describe('Email Validation', () => {
     it('shows validation error for invalid email', async () => {
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
 
       const emailInput = screen.getByPlaceholderText('Enter your email');
       fireEvent.changeText(emailInput, 'invalid-email');
@@ -84,6 +104,10 @@ describe('LoginScreen', () => {
     it('shows validation error for empty email', async () => {
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getAllByText('Sign In')[0]).toBeTruthy();
+      });
+
       const signInButton = screen.getAllByText('Sign In')[0];
       fireEvent.press(signInButton);
 
@@ -94,6 +118,10 @@ describe('LoginScreen', () => {
 
     it('clears email error when user starts typing', async () => {
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
 
       const emailInput = screen.getByPlaceholderText('Enter your email');
       fireEvent.changeText(emailInput, 'invalid');
@@ -119,6 +147,10 @@ describe('LoginScreen', () => {
     it('shows validation error for empty password', async () => {
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       fireEvent.changeText(emailInput, 'test@example.com');
 
@@ -132,6 +164,10 @@ describe('LoginScreen', () => {
 
     it('clears password error when user starts typing', async () => {
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
 
       const emailInput = screen.getByPlaceholderText('Enter your email');
       fireEvent.changeText(emailInput, 'test@example.com');
@@ -163,6 +199,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -193,6 +233,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -216,6 +260,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -236,6 +284,10 @@ describe('LoginScreen', () => {
       );
 
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
 
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
@@ -260,6 +312,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -281,6 +337,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -300,6 +360,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -316,8 +380,12 @@ describe('LoginScreen', () => {
   });
 
   describe('Navigation', () => {
-    it('navigates to Register on register link press', () => {
+    it('navigates to Register on register link press', async () => {
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Don't have an account/)).toBeTruthy();
+      });
 
       const registerLink = screen.getByText(/Don't have an account/);
       fireEvent.press(registerLink);
@@ -325,8 +393,12 @@ describe('LoginScreen', () => {
       expect(mockNavigate).toHaveBeenCalledWith('Register');
     });
 
-    it('navigates to ResetPassword on forgot password link press', () => {
+    it('navigates to ResetPassword on forgot password link press', async () => {
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Forgot password/)).toBeTruthy();
+      });
 
       const forgotLink = screen.getByText(/Forgot password/);
       fireEvent.press(forgotLink);
@@ -349,6 +421,10 @@ describe('LoginScreen', () => {
       );
 
       renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
 
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
@@ -376,6 +452,10 @@ describe('LoginScreen', () => {
 
       renderLoginScreen();
 
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your email')).toBeTruthy();
+      });
+
       const emailInput = screen.getByPlaceholderText('Enter your email');
       const passwordInput = screen.getByPlaceholderText('Enter your password');
 
@@ -394,6 +474,156 @@ describe('LoginScreen', () => {
       await waitFor(() => {
         const errors = screen.queryAllByText('Invalid email or password');
         expect(errors.length).toBe(0);
+      });
+    });
+  });
+
+  describe('Biometric Login', () => {
+    it('does not show biometric button when not available', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: false,
+        biometricType: 'none',
+        isEnrolled: false,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Sign In')).toBeTruthy();
+      });
+
+      expect(screen.queryByTestId('biometric-login-button')).toBeNull();
+    });
+
+    it('does not show biometric button when not enabled', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Sign In')).toBeTruthy();
+      });
+
+      expect(screen.queryByTestId('biometric-login-button')).toBeNull();
+    });
+
+    it('shows biometric button when available and enabled', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(true);
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-login-button')).toBeTruthy();
+      });
+      expect(screen.getByText('Use Face ID')).toBeTruthy();
+    });
+
+    it('shows fingerprint label for fingerprint type', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'fingerprint',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(true);
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Use Fingerprint')).toBeTruthy();
+      });
+    });
+
+    it('calls loginWithBiometric when biometric button pressed', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(true);
+      mockBiometricService.promptBiometric.mockResolvedValue({ success: true });
+      mockBiometricService.getStoredCredentials.mockResolvedValue({
+        refreshToken: 'stored-refresh',
+        email: 'stored@example.com',
+      });
+      mockAuthService.refreshTokens.mockResolvedValue({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresIn: 900,
+      });
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-login-button')).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId('biometric-login-button'));
+
+      await waitFor(() => {
+        expect(mockBiometricService.promptBiometric).toHaveBeenCalled();
+      });
+    });
+
+    it('shows error when biometric login fails', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(true);
+      mockBiometricService.promptBiometric.mockResolvedValue({
+        success: false,
+        error: 'User cancelled',
+      });
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-login-button')).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId('biometric-login-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('User cancelled')).toBeTruthy();
+      });
+    });
+
+    it('shows session expired error when token refresh fails', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(true);
+      mockBiometricService.promptBiometric.mockResolvedValue({ success: true });
+      mockBiometricService.getStoredCredentials.mockResolvedValue({
+        refreshToken: 'expired-refresh',
+        email: 'stored@example.com',
+      });
+      mockAuthService.refreshTokens.mockRejectedValue(new Error('Token expired'));
+
+      renderLoginScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-login-button')).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId('biometric-login-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Session expired. Please sign in with your password.')).toBeTruthy();
       });
     });
   });

--- a/mobile/__tests__/screens/main/SettingsScreen.test.tsx
+++ b/mobile/__tests__/screens/main/SettingsScreen.test.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { SettingsScreen } from '../../../src/screens/main/SettingsScreen';
+import { AuthProvider } from '../../../src/contexts';
+import * as biometricService from '../../../src/services/biometric';
+import * as authService from '../../../src/services/auth';
+import type { MainTabScreenProps } from '../../../src/navigation/types';
+
+jest.mock('../../../src/services/biometric');
+jest.mock('../../../src/services/auth');
+
+const mockBiometricService = biometricService as jest.Mocked<typeof biometricService>;
+const mockAuthService = authService as jest.Mocked<typeof authService>;
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({
+    reset: jest.fn(),
+  })),
+} as unknown as MainTabScreenProps<'Settings'>['navigation'];
+
+const mockRoute = {
+  key: 'Settings',
+  name: 'Settings' as const,
+  params: undefined,
+} as MainTabScreenProps<'Settings'>['route'];
+
+const renderSettingsScreen = () => {
+  return render(
+    <AuthProvider>
+      <NavigationContainer>
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      </NavigationContainer>
+    </AuthProvider>
+  );
+};
+
+describe('SettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default biometric mocks - not available
+    mockBiometricService.checkBiometricCapability.mockResolvedValue({
+      isAvailable: false,
+      biometricType: 'none',
+      isEnrolled: false,
+    });
+    mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+  });
+
+  describe('Rendering', () => {
+    it('renders settings title', async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeTruthy();
+      });
+    });
+
+    it('renders Account section', async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Account')).toBeTruthy();
+      });
+      expect(screen.getByText('Profile')).toBeTruthy();
+      expect(screen.getByText('Currency')).toBeTruthy();
+      expect(screen.getByText('Accounts')).toBeTruthy();
+      expect(screen.getByText('Categories')).toBeTruthy();
+    });
+
+    it('renders Data section', async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Data')).toBeTruthy();
+      });
+      expect(screen.getByText('Export Data')).toBeTruthy();
+      expect(screen.getByText('Delete Account')).toBeTruthy();
+    });
+
+    it('renders About section', async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('About')).toBeTruthy();
+      });
+      expect(screen.getByText('Privacy Policy')).toBeTruthy();
+      expect(screen.getByText('Terms of Service')).toBeTruthy();
+      expect(screen.getByText('Version')).toBeTruthy();
+    });
+
+    it('renders Sign Out button', async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logout-button')).toBeTruthy();
+      });
+      expect(screen.getByText('Sign Out')).toBeTruthy();
+    });
+
+    it('renders app name', async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Balance Beacon')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Biometric Toggle', () => {
+    it('does not show biometric toggle when not available', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: false,
+        biometricType: 'none',
+        isEnrolled: false,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeTruthy();
+      });
+
+      expect(screen.queryByTestId('biometric-switch')).toBeNull();
+      expect(screen.queryByText('Security')).toBeNull();
+    });
+
+    it('shows biometric toggle when available', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Security')).toBeTruthy();
+      });
+      expect(screen.getByTestId('biometric-switch')).toBeTruthy();
+      expect(screen.getByText('Face ID')).toBeTruthy();
+      expect(screen.getByText('Quick unlock with Face ID')).toBeTruthy();
+    });
+
+    it('shows fingerprint label for fingerprint type', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'fingerprint',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByText('Fingerprint')).toBeTruthy();
+      });
+      expect(screen.getByText('Quick unlock with Fingerprint')).toBeTruthy();
+    });
+
+    it('shows switch as on when biometric is enabled', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(true);
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        const biometricSwitch = screen.getByTestId('biometric-switch');
+        expect(biometricSwitch.props.value).toBe(true);
+      });
+    });
+
+    it('shows switch as off when biometric is disabled', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        const biometricSwitch = screen.getByTestId('biometric-switch');
+        expect(biometricSwitch.props.value).toBe(false);
+      });
+    });
+
+    it('shows loading indicator when toggling biometric', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+      mockBiometricService.promptBiometric.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ success: true }), 100))
+      );
+      mockBiometricService.enableBiometric.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-switch')).toBeTruthy();
+      });
+
+      const biometricSwitch = screen.getByTestId('biometric-switch');
+      fireEvent(biometricSwitch, 'valueChange', true);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-loading')).toBeTruthy();
+      });
+    });
+
+    it('shows error when enabling biometric fails', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+      mockBiometricService.promptBiometric.mockResolvedValue({
+        success: false,
+        error: 'User cancelled authentication',
+      });
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-switch')).toBeTruthy();
+      });
+
+      const biometricSwitch = screen.getByTestId('biometric-switch');
+      fireEvent(biometricSwitch, 'valueChange', true);
+
+      await waitFor(() => {
+        expect(screen.getByText('User cancelled authentication')).toBeTruthy();
+      });
+    });
+
+    it('shows generic error when enabling biometric fails with non-Error', async () => {
+      mockBiometricService.checkBiometricCapability.mockResolvedValue({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+      mockBiometricService.isBiometricEnabled.mockResolvedValue(false);
+      mockBiometricService.promptBiometric.mockRejectedValue('unknown error');
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('biometric-switch')).toBeTruthy();
+      });
+
+      const biometricSwitch = screen.getByTestId('biometric-switch');
+      fireEvent(biometricSwitch, 'valueChange', true);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to update biometric settings')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Logout', () => {
+    it('calls logout when Sign Out is pressed', async () => {
+      mockAuthService.logout.mockResolvedValue(undefined);
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logout-button')).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId('logout-button'));
+
+      await waitFor(() => {
+        // Logout should be called (the actual logout behavior is handled by AuthContext)
+        expect(screen.getByTestId('logout-button')).toBeTruthy();
+      });
+    });
+
+    it('shows loading indicator during logout', async () => {
+      mockAuthService.logout.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logout-button')).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId('logout-button'));
+
+      // Button should show loading state (ActivityIndicator replaces text)
+      await waitFor(() => {
+        expect(screen.queryByText('Sign Out')).toBeNull();
+      });
+    });
+
+    it('disables logout button during loading', async () => {
+      mockAuthService.logout.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logout-button')).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId('logout-button'));
+
+      await waitFor(() => {
+        const logoutButton = screen.getByTestId('logout-button');
+        expect(logoutButton.props.accessibilityState?.disabled).toBe(true);
+      });
+    });
+  });
+});

--- a/mobile/__tests__/screens/onboarding/OnboardingBiometricScreen.test.tsx
+++ b/mobile/__tests__/screens/onboarding/OnboardingBiometricScreen.test.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { OnboardingBiometricScreen } from '../../../src/screens/onboarding/OnboardingBiometricScreen';
+import { useAuth } from '../../../src/contexts/AuthContext';
+
+jest.mock('../../../src/contexts/AuthContext');
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  getParent: jest.fn(() => ({
+    reset: jest.fn(),
+  })),
+} as unknown as Parameters<typeof OnboardingBiometricScreen>[0]['navigation'];
+
+const mockRoute = {
+  key: 'OnboardingBiometric',
+  name: 'OnboardingBiometric' as const,
+  params: undefined,
+};
+
+describe('OnboardingBiometricScreen', () => {
+  const defaultAuthValue = {
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: '1', email: 'test@example.com', hasCompletedOnboarding: false },
+    accessToken: 'test-token',
+    biometricCapability: {
+      isAvailable: true,
+      biometricType: 'faceId' as const,
+      isEnrolled: true,
+    },
+    isBiometricEnabled: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+    register: jest.fn(),
+    refreshToken: jest.fn(),
+    updateUser: jest.fn(),
+    loginWithBiometric: jest.fn(),
+    enableBiometric: jest.fn(),
+    disableBiometric: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue(defaultAuthValue);
+  });
+
+  it('renders with biometric available', () => {
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    expect(screen.getByText('Quick Access')).toBeTruthy();
+    expect(screen.getByText(/Use Face ID to quickly unlock/)).toBeTruthy();
+    expect(screen.getByText('Enable Face ID')).toBeTruthy();
+    expect(screen.getByText('Skip for now')).toBeTruthy();
+  });
+
+  it('renders fingerprint label for fingerprint type', () => {
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      biometricCapability: {
+        isAvailable: true,
+        biometricType: 'fingerprint',
+        isEnrolled: true,
+      },
+    });
+
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    expect(screen.getByText(/Use Fingerprint to quickly unlock/)).toBeTruthy();
+    expect(screen.getByText('Enable Fingerprint')).toBeTruthy();
+  });
+
+  it('renders continue button when biometric not available', () => {
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      biometricCapability: {
+        isAvailable: false,
+        biometricType: 'none',
+        isEnrolled: false,
+      },
+    });
+
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    expect(screen.getByText('Biometric authentication is not available on this device.')).toBeTruthy();
+    expect(screen.getByText('Continue')).toBeTruthy();
+    expect(screen.queryByText('Skip for now')).toBeNull();
+  });
+
+  it('enables biometric and completes onboarding on enable button press', async () => {
+    const enableBiometric = jest.fn().mockResolvedValue(undefined);
+    const updateUser = jest.fn();
+    const resetMock = jest.fn();
+    const getParentMock = jest.fn(() => ({ reset: resetMock }));
+
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      enableBiometric,
+      updateUser,
+    });
+
+    render(
+      <OnboardingBiometricScreen
+        navigation={{ ...mockNavigation, getParent: getParentMock } as typeof mockNavigation}
+        route={mockRoute}
+      />
+    );
+
+    fireEvent.press(screen.getByTestId('enable-biometric-button'));
+
+    await waitFor(() => {
+      expect(enableBiometric).toHaveBeenCalled();
+      expect(updateUser).toHaveBeenCalledWith({ hasCompletedOnboarding: true });
+      expect(resetMock).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'App' }],
+      });
+    });
+  });
+
+  it('shows error when enable fails', async () => {
+    const enableBiometric = jest.fn().mockRejectedValue(new Error('Biometric failed'));
+
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      enableBiometric,
+    });
+
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    fireEvent.press(screen.getByTestId('enable-biometric-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Biometric failed')).toBeTruthy();
+    });
+  });
+
+  it('shows generic error when enable fails with non-Error', async () => {
+    const enableBiometric = jest.fn().mockRejectedValue('unknown error');
+
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      enableBiometric,
+    });
+
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    fireEvent.press(screen.getByTestId('enable-biometric-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to enable biometric authentication')).toBeTruthy();
+    });
+  });
+
+  it('completes onboarding on skip button press', async () => {
+    const updateUser = jest.fn();
+    const resetMock = jest.fn();
+    const getParentMock = jest.fn(() => ({ reset: resetMock }));
+
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      updateUser,
+    });
+
+    render(
+      <OnboardingBiometricScreen
+        navigation={{ ...mockNavigation, getParent: getParentMock } as typeof mockNavigation}
+        route={mockRoute}
+      />
+    );
+
+    fireEvent.press(screen.getByTestId('skip-button'));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledWith({ hasCompletedOnboarding: true });
+      expect(resetMock).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'App' }],
+      });
+    });
+  });
+
+  it('completes onboarding on continue button when biometric unavailable', async () => {
+    const updateUser = jest.fn();
+    const resetMock = jest.fn();
+    const getParentMock = jest.fn(() => ({ reset: resetMock }));
+
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      biometricCapability: {
+        isAvailable: false,
+        biometricType: 'none',
+        isEnrolled: false,
+      },
+      updateUser,
+    });
+
+    render(
+      <OnboardingBiometricScreen
+        navigation={{ ...mockNavigation, getParent: getParentMock } as typeof mockNavigation}
+        route={mockRoute}
+      />
+    );
+
+    fireEvent.press(screen.getByTestId('continue-button'));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledWith({ hasCompletedOnboarding: true });
+      expect(resetMock).toHaveBeenCalled();
+    });
+  });
+
+  it('shows loading state during enable', async () => {
+    const enableBiometric = jest.fn().mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 100))
+    );
+
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      enableBiometric,
+    });
+
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    fireEvent.press(screen.getByTestId('enable-biometric-button'));
+
+    // Button should show loading indicator (ActivityIndicator)
+    await waitFor(() => {
+      expect(screen.queryByText('Enable Face ID')).toBeNull();
+    });
+  });
+
+  it('renders step indicator', () => {
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    expect(screen.getByText('Step 6 of 6')).toBeTruthy();
+  });
+
+  it('renders correct icon for Face ID', () => {
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    // The component should render a face icon for faceId type
+    // We check the parent icon container exists
+    expect(screen.getByText('Quick Access')).toBeTruthy();
+  });
+
+  it('handles null biometricCapability', () => {
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthValue,
+      biometricCapability: null,
+    });
+
+    render(
+      <OnboardingBiometricScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    expect(screen.getByText('Biometric authentication is not available on this device.')).toBeTruthy();
+    expect(screen.getByText('Continue')).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/services/biometric.test.ts
+++ b/mobile/__tests__/services/biometric.test.ts
@@ -1,0 +1,402 @@
+import * as LocalAuthentication from 'expo-local-authentication';
+import * as SecureStore from 'expo-secure-store';
+import {
+  checkBiometricCapability,
+  promptBiometric,
+  enableBiometric,
+  disableBiometric,
+  isBiometricEnabled,
+  getStoredCredentials,
+  clearStoredCredentials,
+  getBiometricTypeLabel,
+  STORAGE_KEYS,
+} from '../../src/services/biometric';
+
+jest.mock('expo-local-authentication');
+jest.mock('expo-secure-store');
+
+const mockLocalAuth = LocalAuthentication as jest.Mocked<typeof LocalAuthentication>;
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+describe('biometric service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('checkBiometricCapability', () => {
+    it('returns not available when no hardware', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(false);
+
+      const result = await checkBiometricCapability();
+
+      expect(result).toEqual({
+        isAvailable: false,
+        biometricType: 'none',
+        isEnrolled: false,
+      });
+    });
+
+    it('returns Face ID type when available', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(true);
+      mockLocalAuth.isEnrolledAsync.mockResolvedValue(true);
+      mockLocalAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+        LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION,
+      ]);
+
+      const result = await checkBiometricCapability();
+
+      expect(result).toEqual({
+        isAvailable: true,
+        biometricType: 'faceId',
+        isEnrolled: true,
+      });
+    });
+
+    it('returns fingerprint type when available', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(true);
+      mockLocalAuth.isEnrolledAsync.mockResolvedValue(true);
+      mockLocalAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+        LocalAuthentication.AuthenticationType.FINGERPRINT,
+      ]);
+
+      const result = await checkBiometricCapability();
+
+      expect(result).toEqual({
+        isAvailable: true,
+        biometricType: 'fingerprint',
+        isEnrolled: true,
+      });
+    });
+
+    it('returns iris type when available', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(true);
+      mockLocalAuth.isEnrolledAsync.mockResolvedValue(true);
+      mockLocalAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+        LocalAuthentication.AuthenticationType.IRIS,
+      ]);
+
+      const result = await checkBiometricCapability();
+
+      expect(result).toEqual({
+        isAvailable: true,
+        biometricType: 'iris',
+        isEnrolled: true,
+      });
+    });
+
+    it('prefers Face ID when multiple types available', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(true);
+      mockLocalAuth.isEnrolledAsync.mockResolvedValue(true);
+      mockLocalAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+        LocalAuthentication.AuthenticationType.FINGERPRINT,
+        LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION,
+      ]);
+
+      const result = await checkBiometricCapability();
+
+      expect(result.biometricType).toBe('faceId');
+    });
+
+    it('returns not available when hardware exists but not enrolled', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(true);
+      mockLocalAuth.isEnrolledAsync.mockResolvedValue(false);
+      mockLocalAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+        LocalAuthentication.AuthenticationType.FINGERPRINT,
+      ]);
+
+      const result = await checkBiometricCapability();
+
+      expect(result).toEqual({
+        isAvailable: false,
+        biometricType: 'fingerprint',
+        isEnrolled: false,
+      });
+    });
+
+    it('returns none type when no supported types', async () => {
+      mockLocalAuth.hasHardwareAsync.mockResolvedValue(true);
+      mockLocalAuth.isEnrolledAsync.mockResolvedValue(true);
+      mockLocalAuth.supportedAuthenticationTypesAsync.mockResolvedValue([]);
+
+      const result = await checkBiometricCapability();
+
+      expect(result.biometricType).toBe('none');
+    });
+  });
+
+  describe('promptBiometric', () => {
+    it('returns success on successful authentication', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: true,
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({ success: true });
+      expect(mockLocalAuth.authenticateAsync).toHaveBeenCalledWith({
+        promptMessage: 'Authenticate to continue',
+        fallbackLabel: 'Use password',
+        disableDeviceFallback: true,
+      });
+    });
+
+    it('uses custom reason when provided', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: true,
+      });
+
+      await promptBiometric('Unlock Balance Beacon');
+
+      expect(mockLocalAuth.authenticateAsync).toHaveBeenCalledWith({
+        promptMessage: 'Unlock Balance Beacon',
+        fallbackLabel: 'Use password',
+        disableDeviceFallback: true,
+      });
+    });
+
+    it('returns error on user cancel', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'user_cancel',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Authentication was cancelled',
+      });
+    });
+
+    it('returns error on user fallback', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'user_fallback',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'User chose to use password',
+      });
+    });
+
+    it('returns error on system cancel', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'system_cancel',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Authentication was cancelled by the system',
+      });
+    });
+
+    it('returns error when not enrolled', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'not_enrolled',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'No biometrics enrolled on this device',
+      });
+    });
+
+    it('returns error on lockout', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'lockout',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Too many failed attempts. Please try again later.',
+      });
+    });
+
+    it('returns error on permanent lockout', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'lockout_permanent',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Biometric authentication is locked. Please use your password.',
+      });
+    });
+
+    it('returns generic error on unknown error', async () => {
+      mockLocalAuth.authenticateAsync.mockResolvedValue({
+        success: false,
+        error: 'unknown_error',
+      });
+
+      const result = await promptBiometric();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Authentication failed',
+      });
+    });
+  });
+
+  describe('enableBiometric', () => {
+    it('stores credentials and enables flag', async () => {
+      await enableBiometric('refresh-token-123', 'user@example.com');
+
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledTimes(3);
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.REFRESH_TOKEN,
+        'refresh-token-123'
+      );
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.USER_EMAIL,
+        'user@example.com'
+      );
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.BIOMETRIC_ENABLED,
+        'true'
+      );
+    });
+  });
+
+  describe('disableBiometric', () => {
+    it('clears credentials and sets flag to false', async () => {
+      await disableBiometric();
+
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.REFRESH_TOKEN
+      );
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.USER_EMAIL
+      );
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.BIOMETRIC_ENABLED,
+        'false'
+      );
+    });
+  });
+
+  describe('isBiometricEnabled', () => {
+    it('returns true when enabled', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValue('true');
+
+      const result = await isBiometricEnabled();
+
+      expect(result).toBe(true);
+      expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.BIOMETRIC_ENABLED
+      );
+    });
+
+    it('returns false when disabled', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValue('false');
+
+      const result = await isBiometricEnabled();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when not set', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValue(null);
+
+      const result = await isBiometricEnabled();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getStoredCredentials', () => {
+    it('returns credentials when stored', async () => {
+      mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+        if (key === STORAGE_KEYS.REFRESH_TOKEN) return 'stored-refresh-token';
+        if (key === STORAGE_KEYS.USER_EMAIL) return 'stored@example.com';
+        return null;
+      });
+
+      const result = await getStoredCredentials();
+
+      expect(result).toEqual({
+        refreshToken: 'stored-refresh-token',
+        email: 'stored@example.com',
+      });
+    });
+
+    it('returns null when refresh token missing', async () => {
+      mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+        if (key === STORAGE_KEYS.USER_EMAIL) return 'stored@example.com';
+        return null;
+      });
+
+      const result = await getStoredCredentials();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when email missing', async () => {
+      mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+        if (key === STORAGE_KEYS.REFRESH_TOKEN) return 'stored-refresh-token';
+        return null;
+      });
+
+      const result = await getStoredCredentials();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when nothing stored', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValue(null);
+
+      const result = await getStoredCredentials();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('clearStoredCredentials', () => {
+    it('removes all stored data', async () => {
+      await clearStoredCredentials();
+
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.REFRESH_TOKEN
+      );
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.USER_EMAIL
+      );
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        STORAGE_KEYS.BIOMETRIC_ENABLED
+      );
+    });
+  });
+
+  describe('getBiometricTypeLabel', () => {
+    it('returns Face ID for faceId type', () => {
+      expect(getBiometricTypeLabel('faceId')).toBe('Face ID');
+    });
+
+    it('returns Fingerprint for fingerprint type', () => {
+      expect(getBiometricTypeLabel('fingerprint')).toBe('Fingerprint');
+    });
+
+    it('returns Iris for iris type', () => {
+      expect(getBiometricTypeLabel('iris')).toBe('Iris');
+    });
+
+    it('returns Biometric for none type', () => {
+      expect(getBiometricTypeLabel('none')).toBe('Biometric');
+    });
+  });
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,8 @@
     "@react-navigation/native": "^6.1.0",
     "@react-navigation/native-stack": "^6.10.0",
     "expo": "~54.0.31",
+    "expo-local-authentication": "~15.0.2",
+    "expo-secure-store": "~14.2.3",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -191,8 +191,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
         email: credentials.email,
         hasCompletedOnboarding: true,
       });
-    } catch {
+    } catch (error) {
       // Clear invalid credentials
+      if (__DEV__) {
+        // eslint-disable-next-line no-console
+        console.error('Biometric login failed during token refresh:', error);
+      }
       await biometricService.clearStoredCredentials();
       setIsBiometricEnabled(false);
       throw new ApiError(

--- a/mobile/src/navigation/OnboardingStack.tsx
+++ b/mobile/src/navigation/OnboardingStack.tsx
@@ -8,6 +8,7 @@ import {
   OnboardingBudgetScreen,
   OnboardingSampleDataScreen,
   OnboardingCompleteScreen,
+  OnboardingBiometricScreen,
 } from '../screens';
 
 const Stack = createNativeStackNavigator<OnboardingStackParamList>();
@@ -45,6 +46,10 @@ export function OnboardingStack() {
       <Stack.Screen
         name="OnboardingComplete"
         component={OnboardingCompleteScreen}
+      />
+      <Stack.Screen
+        name="OnboardingBiometric"
+        component={OnboardingBiometricScreen}
       />
     </Stack.Navigator>
   );

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -21,6 +21,7 @@ export type OnboardingStackParamList = {
   OnboardingBudget: undefined;
   OnboardingSampleData: undefined;
   OnboardingComplete: undefined;
+  OnboardingBiometric: undefined;
 };
 
 // Main Tab Navigator

--- a/mobile/src/screens/index.ts
+++ b/mobile/src/screens/index.ts
@@ -11,6 +11,7 @@ export { OnboardingCategoriesScreen } from './onboarding/OnboardingCategoriesScr
 export { OnboardingBudgetScreen } from './onboarding/OnboardingBudgetScreen';
 export { OnboardingSampleDataScreen } from './onboarding/OnboardingSampleDataScreen';
 export { OnboardingCompleteScreen } from './onboarding/OnboardingCompleteScreen';
+export { OnboardingBiometricScreen } from './onboarding/OnboardingBiometricScreen';
 
 // Main screens
 export { DashboardScreen } from './main/DashboardScreen';

--- a/mobile/src/screens/onboarding/OnboardingBiometricScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingBiometricScreen.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../../contexts/AuthContext';
+import { getBiometricTypeLabel } from '../../services/biometric';
+import type { OnboardingScreenProps } from '../../navigation/types';
+
+export function OnboardingBiometricScreen({
+  navigation,
+}: OnboardingScreenProps<'OnboardingBiometric'>) {
+  const { biometricCapability, enableBiometric, updateUser } = useAuth();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const biometricLabel = biometricCapability
+    ? getBiometricTypeLabel(biometricCapability.biometricType)
+    : 'Biometric';
+
+  const handleEnable = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await enableBiometric();
+      completeOnboarding();
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Failed to enable biometric authentication');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSkip = () => {
+    completeOnboarding();
+  };
+
+  const completeOnboarding = () => {
+    updateUser({ hasCompletedOnboarding: true });
+    navigation.getParent()?.reset({
+      index: 0,
+      routes: [{ name: 'App' }],
+    });
+  };
+
+  const biometricAvailable = biometricCapability?.isAvailable;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.stepIndicator}>Step 6 of 6</Text>
+        <View style={styles.iconContainer}>
+          <Text style={styles.icon}>
+            {biometricCapability?.biometricType === 'faceId' ? '👤' : '👆'}
+          </Text>
+        </View>
+        <Text style={styles.title}>Quick Access</Text>
+        <Text style={styles.subtitle}>
+          {biometricAvailable
+            ? `Use ${biometricLabel} to quickly unlock the app without entering your password.`
+            : 'Biometric authentication is not available on this device.'}
+        </Text>
+
+        {error && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        {biometricAvailable ? (
+          <>
+            <Pressable
+              style={[styles.button, isLoading && styles.buttonDisabled]}
+              onPress={handleEnable}
+              disabled={isLoading}
+              testID="enable-biometric-button"
+            >
+              {isLoading ? (
+                <ActivityIndicator color="#0f172a" />
+              ) : (
+                <Text style={styles.buttonText}>Enable {biometricLabel}</Text>
+              )}
+            </Pressable>
+
+            <Pressable
+              style={styles.skipButton}
+              onPress={handleSkip}
+              disabled={isLoading}
+              testID="skip-button"
+            >
+              <Text style={styles.skipButtonText}>Skip for now</Text>
+            </Pressable>
+          </>
+        ) : (
+          <Pressable
+            style={styles.button}
+            onPress={handleSkip}
+            testID="continue-button"
+          >
+            <Text style={styles.buttonText}>Continue</Text>
+          </Pressable>
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f172a',
+  },
+  content: {
+    flex: 1,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  stepIndicator: {
+    fontSize: 14,
+    color: '#38bdf8',
+    marginBottom: 24,
+  },
+  iconContainer: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: 'rgba(56,189,248,0.2)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  icon: {
+    fontSize: 40,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#fff',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#94a3b8',
+    marginBottom: 32,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  errorContainer: {
+    backgroundColor: 'rgba(239,68,68,0.1)',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 16,
+    width: '100%',
+  },
+  errorText: {
+    color: '#ef4444',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  button: {
+    width: '100%',
+    backgroundColor: '#38bdf8',
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 12,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#0f172a',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  skipButton: {
+    paddingVertical: 12,
+  },
+  skipButtonText: {
+    color: '#94a3b8',
+    fontSize: 16,
+  },
+});

--- a/mobile/src/screens/onboarding/OnboardingCompleteScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingCompleteScreen.tsx
@@ -3,7 +3,9 @@ import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { OnboardingScreenProps } from '../../navigation/types';
 
-export function OnboardingCompleteScreen(_props: OnboardingScreenProps<'OnboardingComplete'>) {
+export function OnboardingCompleteScreen({
+  navigation,
+}: OnboardingScreenProps<'OnboardingComplete'>) {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
@@ -31,8 +33,12 @@ export function OnboardingCompleteScreen(_props: OnboardingScreenProps<'Onboardi
           </View>
         </View>
 
-        <Pressable style={styles.button}>
-          <Text style={styles.buttonText}>Start Tracking</Text>
+        <Pressable
+          style={styles.button}
+          onPress={() => navigation.navigate('OnboardingBiometric')}
+          testID="continue-button"
+        >
+          <Text style={styles.buttonText}>Continue</Text>
         </Pressable>
       </View>
     </SafeAreaView>

--- a/mobile/src/screens/onboarding/OnboardingCompleteScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingCompleteScreen.tsx
@@ -9,7 +9,7 @@ export function OnboardingCompleteScreen({
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.stepIndicator}>Step 5 of 5</Text>
+        <Text style={styles.stepIndicator}>Step 5 of 6</Text>
         <View style={styles.successIcon}>
           <Text style={styles.successEmoji}>✓</Text>
         </View>

--- a/mobile/src/services/biometric.ts
+++ b/mobile/src/services/biometric.ts
@@ -1,0 +1,178 @@
+import * as LocalAuthentication from 'expo-local-authentication';
+import * as SecureStore from 'expo-secure-store';
+
+export const STORAGE_KEYS = {
+  BIOMETRIC_ENABLED: 'balance_beacon_biometric_enabled',
+  REFRESH_TOKEN: 'balance_beacon_refresh_token',
+  USER_EMAIL: 'balance_beacon_user_email',
+} as const;
+
+export type BiometricType = 'fingerprint' | 'faceId' | 'iris' | 'none';
+
+export interface BiometricCapability {
+  isAvailable: boolean;
+  biometricType: BiometricType;
+  isEnrolled: boolean;
+}
+
+export interface BiometricAuthResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface StoredCredentials {
+  refreshToken: string;
+  email: string;
+}
+
+/**
+ * Check what biometric capabilities are available on this device
+ */
+export async function checkBiometricCapability(): Promise<BiometricCapability> {
+  const hasHardware = await LocalAuthentication.hasHardwareAsync();
+
+  if (!hasHardware) {
+    return {
+      isAvailable: false,
+      biometricType: 'none',
+      isEnrolled: false,
+    };
+  }
+
+  const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+  const supportedTypes =
+    await LocalAuthentication.supportedAuthenticationTypesAsync();
+
+  let biometricType: BiometricType = 'none';
+
+  if (
+    supportedTypes.includes(LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION)
+  ) {
+    biometricType = 'faceId';
+  } else if (
+    supportedTypes.includes(LocalAuthentication.AuthenticationType.FINGERPRINT)
+  ) {
+    biometricType = 'fingerprint';
+  } else if (
+    supportedTypes.includes(LocalAuthentication.AuthenticationType.IRIS)
+  ) {
+    biometricType = 'iris';
+  }
+
+  return {
+    isAvailable: hasHardware && isEnrolled,
+    biometricType,
+    isEnrolled,
+  };
+}
+
+/**
+ * Prompt the user for biometric authentication
+ */
+export async function promptBiometric(
+  reason: string = 'Authenticate to continue'
+): Promise<BiometricAuthResult> {
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage: reason,
+    fallbackLabel: 'Use password',
+    disableDeviceFallback: true,
+  });
+
+  if (result.success) {
+    return { success: true };
+  }
+
+  let error: string;
+  switch (result.error) {
+    case 'user_cancel':
+      error = 'Authentication was cancelled';
+      break;
+    case 'user_fallback':
+      error = 'User chose to use password';
+      break;
+    case 'system_cancel':
+      error = 'Authentication was cancelled by the system';
+      break;
+    case 'not_enrolled':
+      error = 'No biometrics enrolled on this device';
+      break;
+    case 'lockout':
+      error = 'Too many failed attempts. Please try again later.';
+      break;
+    case 'lockout_permanent':
+      error = 'Biometric authentication is locked. Please use your password.';
+      break;
+    default:
+      error = 'Authentication failed';
+  }
+
+  return { success: false, error };
+}
+
+/**
+ * Enable biometric authentication by storing credentials securely
+ */
+export async function enableBiometric(
+  refreshToken: string,
+  userEmail: string
+): Promise<void> {
+  await SecureStore.setItemAsync(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
+  await SecureStore.setItemAsync(STORAGE_KEYS.USER_EMAIL, userEmail);
+  await SecureStore.setItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED, 'true');
+}
+
+/**
+ * Disable biometric authentication and clear stored credentials
+ */
+export async function disableBiometric(): Promise<void> {
+  await SecureStore.deleteItemAsync(STORAGE_KEYS.REFRESH_TOKEN);
+  await SecureStore.deleteItemAsync(STORAGE_KEYS.USER_EMAIL);
+  await SecureStore.setItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED, 'false');
+}
+
+/**
+ * Check if biometric authentication is enabled
+ */
+export async function isBiometricEnabled(): Promise<boolean> {
+  const enabled = await SecureStore.getItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED);
+  return enabled === 'true';
+}
+
+/**
+ * Get stored credentials for biometric login
+ */
+export async function getStoredCredentials(): Promise<StoredCredentials | null> {
+  const refreshToken = await SecureStore.getItemAsync(STORAGE_KEYS.REFRESH_TOKEN);
+  const email = await SecureStore.getItemAsync(STORAGE_KEYS.USER_EMAIL);
+
+  if (!refreshToken || !email) {
+    return null;
+  }
+
+  return { refreshToken, email };
+}
+
+/**
+ * Clear all stored credentials (used on logout or token expiry)
+ */
+export async function clearStoredCredentials(): Promise<void> {
+  await SecureStore.deleteItemAsync(STORAGE_KEYS.REFRESH_TOKEN);
+  await SecureStore.deleteItemAsync(STORAGE_KEYS.USER_EMAIL);
+  await SecureStore.deleteItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED);
+}
+
+/**
+ * Get user-friendly label for biometric type
+ */
+export function getBiometricTypeLabel(type: BiometricType): string {
+  switch (type) {
+    case 'faceId':
+      return 'Face ID';
+    case 'fingerprint':
+      return 'Fingerprint';
+    case 'iris':
+      return 'Iris';
+    default:
+      return 'Biometric';
+  }
+}

--- a/mobile/src/services/biometric.ts
+++ b/mobile/src/services/biometric.ts
@@ -116,18 +116,22 @@ export async function enableBiometric(
   refreshToken: string,
   userEmail: string
 ): Promise<void> {
-  await SecureStore.setItemAsync(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
-  await SecureStore.setItemAsync(STORAGE_KEYS.USER_EMAIL, userEmail);
-  await SecureStore.setItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED, 'true');
+  await Promise.all([
+    SecureStore.setItemAsync(STORAGE_KEYS.REFRESH_TOKEN, refreshToken),
+    SecureStore.setItemAsync(STORAGE_KEYS.USER_EMAIL, userEmail),
+    SecureStore.setItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED, 'true'),
+  ]);
 }
 
 /**
  * Disable biometric authentication and clear stored credentials
  */
 export async function disableBiometric(): Promise<void> {
-  await SecureStore.deleteItemAsync(STORAGE_KEYS.REFRESH_TOKEN);
-  await SecureStore.deleteItemAsync(STORAGE_KEYS.USER_EMAIL);
-  await SecureStore.setItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED, 'false');
+  await Promise.all([
+    SecureStore.deleteItemAsync(STORAGE_KEYS.REFRESH_TOKEN),
+    SecureStore.deleteItemAsync(STORAGE_KEYS.USER_EMAIL),
+    SecureStore.setItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED, 'false'),
+  ]);
 }
 
 /**
@@ -156,9 +160,11 @@ export async function getStoredCredentials(): Promise<StoredCredentials | null> 
  * Clear all stored credentials (used on logout or token expiry)
  */
 export async function clearStoredCredentials(): Promise<void> {
-  await SecureStore.deleteItemAsync(STORAGE_KEYS.REFRESH_TOKEN);
-  await SecureStore.deleteItemAsync(STORAGE_KEYS.USER_EMAIL);
-  await SecureStore.deleteItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED);
+  await Promise.all([
+    SecureStore.deleteItemAsync(STORAGE_KEYS.REFRESH_TOKEN),
+    SecureStore.deleteItemAsync(STORAGE_KEYS.USER_EMAIL),
+    SecureStore.deleteItemAsync(STORAGE_KEYS.BIOMETRIC_ENABLED),
+  ]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements biometric authentication (Face ID/Touch ID/Fingerprint) for the Balance Beacon mobile app, enabling users to quickly unlock the app after initial password login.

### Key Features
- **Biometric Login Button** on LoginScreen when biometric is available and enabled
- **Settings Toggle** to enable/disable biometric authentication
- **Onboarding Step** (Step 6/6) for initial biometric setup after registration
- **Secure Token Storage** using expo-secure-store for encrypted credential storage
- **Token Rotation Support** - stored refresh tokens are updated when rotated

### Technical Implementation
- New `biometric.ts` service with expo-local-authentication integration
- Extended AuthContext with `loginWithBiometric()`, `enableBiometric()`, `disableBiometric()` methods
- Comprehensive error handling for all biometric failure states
- User-friendly error messages and loading states

### Files Changed
- 15 files changed, 2,396 lines added
- New files: biometric.ts, OnboardingBiometricScreen.tsx, biometric.test.ts
- Modified: AuthContext.tsx, LoginScreen.tsx, SettingsScreen.tsx, navigation files

## Test Plan

- [x] All mobile tests pass (`npm test` in mobile directory)
- [x] TypeScript compiles without errors
- [x] ESLint passes with 0 warnings
- [x] Acceptance criteria met:
  - [x] Biometric login works on supported devices
  - [x] Password fallback always available
  - [x] Permission denial handled gracefully

### Test Coverage
- 402 lines of tests for biometric service
- Integration tests for AuthContext biometric flows
- UI tests for LoginScreen, SettingsScreen, OnboardingBiometricScreen

Closes #80