### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/tests/security/xss-helpers.ts
+++ b/tests/security/xss-helpers.ts
@@ -13,7 +13,7 @@
  */
 export function assertNoExecutableScript(html: string, payload: string) {
   // Should NOT contain unescaped script tags
-  const scriptTagPattern = /<script[^>]*>[\s\S]*?<\/script\s*[^>]*?>/i
+  const scriptTagPattern = /<script[^>]*>[\s\S]*?<\/script[^<]*>/i
   if (scriptTagPattern.test(html)) {
     throw new Error(`HTML contains executable script tag. Payload: ${payload}\nHTML snippet: ${html.substring(0, 200)}`)
   }


### PR DESCRIPTION
Potential fix for [https://github.com/avifenesh/balance-beacon/security/code-scanning/3](https://github.com/avifenesh/balance-beacon/security/code-scanning/3)

In general, the fix is to make the script-tag-detection regex more tolerant of the variants that browsers accept for closing `</script>` tags, including optional whitespace and even invalid-but-accepted trailing attributes before the closing `>`. Instead of matching only `</script>`, the pattern should match `</script` followed by any characters that are not `<` (to avoid spanning into the next tag) until the `>` that actually terminates the closing tag, while remaining case-insensitive.

The best targeted fix without altering overall functionality is to adjust `scriptTagPattern` on line 16 to something like:

```ts
const scriptTagPattern = /<script[^>]*>[\s\S]*?<\/script[^<]*>/i
```

Changes:
- Keep the start tag portion `/<script[^>]*>/` as-is.
- Replace the closing part `</script>` with `</script[^<]*>`:
  - `</script` matches the tag name (case-insensitive due to `/i`).
  - `[^<]*` allows spaces or bogus attributes until the `>`, but stops if a `<` appears (so it doesn’t gobble into the next tag).
  - `>` is included as part of the literal closing delimiter.
This will now match `</script>`, `</script >`, `</script foo="bar">`, etc., better reflecting how browsers terminate script elements. No new imports or helpers are required; we only adjust the literal regex in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
