### PR TITLE
Fix iOS e2e workflow DB URL credentials drift

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -59,7 +59,8 @@ jobs:
           npx prisma db push
           npm run build
         env:
-          DATABASE_URL: postgresql://runner@localhost:5432/expense_track_test
+          # Password must match Setup PostgreSQL ALTER USER $(whoami) command.
+          DATABASE_URL: postgresql://runner:postgres@localhost:5432/expense_track_test
           JWT_SECRET: e2e-test-secret-key-for-jwt-signing
           JWT_REFRESH_SECRET: e2e-test-refresh-secret-key
           AUTH_SESSION_SECRET: e2e-test-session-secret-at-least-32-chars
@@ -70,7 +71,8 @@ jobs:
       - name: Seed test users
         run: npm run db:seed:e2e
         env:
-          DATABASE_URL: postgresql://runner@localhost:5432/expense_track_test
+          # Password must match Setup PostgreSQL ALTER USER $(whoami) command.
+          DATABASE_URL: postgresql://runner:postgres@localhost:5432/expense_track_test
           # TEST_USER: e2e-test@test.local / TestPassword123!
           AUTH_USER1_EMAIL: e2e-test@test.local
           AUTH_USER1_DISPLAY_NAME: E2E Test User
@@ -103,7 +105,8 @@ jobs:
           fi
           echo "Server healthy with status: $FINAL_STATUS"
         env:
-          DATABASE_URL: postgresql://runner@localhost:5432/expense_track_test
+          # Password must match Setup PostgreSQL ALTER USER $(whoami) command.
+          DATABASE_URL: postgresql://runner:postgres@localhost:5432/expense_track_test
           JWT_SECRET: e2e-test-secret-key-for-jwt-signing
           JWT_REFRESH_SECRET: e2e-test-refresh-secret-key
           AUTH_SESSION_SECRET: e2e-test-session-secret-at-least-32-chars


### PR DESCRIPTION
### Motivation
- The macOS setup step sets a password for the runner user via `ALTER USER $(whoami) WITH PASSWORD 'postgres';`, but subsequent iOS steps used a passwordless DB URL which can cause connection failures and drift between setup and runtime.
- Ensure Prisma push, seeding, and the backend runtime all use identical, credentialed connection strings to avoid intermittent e2e failures on the iOS job.

### Description
- Replaced the three iOS `DATABASE_URL` entries in `.github/workflows/e2e-mobile.yml` so they use `postgresql://runner:postgres@localhost:5432/expense_track_test` for `Setup database and build backend`, `Seed test users`, and `Start backend server`.
- Added a short inline comment above each updated `env` block noting the password must match the earlier `ALTER USER $(whoami)` setup command to prevent future drift.
- Kept the DB username aligned with the runner user (`runner` / `$(whoami)`) as used in the setup step.

### Testing
- Verified the change with `git diff -- .github/workflows/e2e-mobile.yml` which shows the updated credentialed URLs and comments, and the check succeeded.
- Confirmed all occurrences with `rg -n "postgresql://runner(@|:postgres@)localhost:5432/expense_track_test|ALTER USER \$\(whoami\)" .github/workflows/e2e-mobile.yml` and the search succeeded.
- Committed the change (`git status --short` and `git commit -m 'Fix iOS e2e DATABASE_URL to include postgres password'`) and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e60d9504833384d46ac70ca9dd98)