### PR TITLE
fix: remaining audit items — pool config, chat retry, email validation, GDPR cleanup

### DIFF
--- a/src/app/actions/account.ts
+++ b/src/app/actions/account.ts
@@ -72,14 +72,16 @@ export async function deleteAccountAction(input: z.infer<typeof deleteAccountSch
     })
     const categoryIds = userCategories.map((c) => c.id)
 
-    // 0. Cancel any pending shared expenses owned by this user
-    await prisma.sharedExpense.updateMany({
-      where: { ownerId: authUser.id, deletedAt: null },
-      data: { deletedAt: new Date(), deletedBy: authUser.id },
-    })
-
     // Build deletion operations, skipping empty array conditions to avoid SQL issues
     const deleteOps = []
+
+    // 0. Cancel pending shared expenses owned by this user (inside transaction)
+    deleteOps.push(
+      prisma.sharedExpense.updateMany({
+        where: { ownerId: authUser.id, deletedAt: null },
+        data: { deletedAt: new Date(), deletedBy: authUser.id },
+      }),
+    )
 
     // 1. TransactionRequest - depends on Account, Category (special case: fromId/toId)
     if (accountIds.length > 0 || categoryIds.length > 0) {

--- a/src/app/actions/account.ts
+++ b/src/app/actions/account.ts
@@ -72,6 +72,12 @@ export async function deleteAccountAction(input: z.infer<typeof deleteAccountSch
     })
     const categoryIds = userCategories.map((c) => c.id)
 
+    // 0. Cancel any pending shared expenses owned by this user
+    await prisma.sharedExpense.updateMany({
+      where: { ownerId: authUser.id, deletedAt: null },
+      data: { deletedAt: new Date(), deletedBy: authUser.id },
+    })
+
     // Build deletion operations, skipping empty array conditions to avoid SQL issues
     const deleteOps = []
 

--- a/src/components/ai/chat-widget.tsx
+++ b/src/components/ai/chat-widget.tsx
@@ -75,6 +75,7 @@ export function ChatWidget({ accountId, monthKey, preferredCurrency }: ChatWidge
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const [lastFailedInput, setLastFailedInput] = useState<string | null>(null)
   const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null)
 
   // Throttled streaming: track pending content and use RAF to batch updates
@@ -282,13 +283,15 @@ export function ChatWidget({ accountId, monthKey, preferredCurrency }: ChatWidge
     event.preventDefault()
     if (!input.trim() || isLoading || !currentSession) return
 
+    const trimmedInput = input.trim()
     const baseMessages = currentSession.messages
     const sessionId = currentSession.id
+    setLastFailedInput(null)
 
     const userMessage: Message = {
       id: generateMessageId(),
       role: 'user',
-      content: input.trim(),
+      content: trimmedInput,
     }
 
     applyMessagesUpdate(sessionId, (existing) => [...existing, userMessage])
@@ -446,6 +449,7 @@ export function ChatWidget({ accountId, monthKey, preferredCurrency }: ChatWidge
           },
         ])
       } else {
+        setLastFailedInput(trimmedInput)
         applyMessagesUpdate(sessionId, (existing) => [
           ...existing,
           {
@@ -690,6 +694,21 @@ export function ChatWidget({ accountId, monthKey, preferredCurrency }: ChatWidge
 
           <div ref={messagesEndRef} />
         </div>
+
+        {lastFailedInput && !isLoading && (
+          <div className="border-t border-white/10 px-5 py-2">
+            <button
+              type="button"
+              onClick={() => {
+                setInput(lastFailedInput)
+                setLastFailedInput(null)
+              }}
+              className="w-full rounded-lg bg-sky-500/20 px-3 py-1.5 text-xs text-sky-300 hover:bg-sky-500/30 transition"
+            >
+              Retry last message
+            </button>
+          </div>
+        )}
 
         <form onSubmit={handleSubmit} className="border-t border-white/10 bg-slate-950/60 px-5 py-4">
           <div className="flex items-end gap-2">

--- a/src/components/dashboard/share-expense-form.tsx
+++ b/src/components/dashboard/share-expense-form.tsx
@@ -50,6 +50,7 @@ export function ShareExpenseForm({
   const [splitType, setSplitType] = useState<SplitType>(SplitType.EQUAL)
   const [participants, setParticipants] = useState<Participant[]>([])
   const [newEmail, setNewEmail] = useState('')
+  const [emailError, setEmailError] = useState<string | null>(null)
   const [description, setDescription] = useState(transactionDescription || '')
   const [isPending, startTransition] = useTransition()
   const [isLookingUp, startLookup] = useTransition()
@@ -156,11 +157,7 @@ export function ShareExpenseForm({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Backdrop - disable interactions while submitting */}
-      <div
-        className="absolute inset-0 bg-black/50"
-        onClick={!isPending ? onClose : undefined}
-        aria-hidden="true"
-      />
+      <div className="absolute inset-0 bg-black/50" onClick={!isPending ? onClose : undefined} aria-hidden="true" />
       <div className="relative z-10 w-full max-w-lg rounded-2xl border border-white/20 bg-slate-900 p-6 shadow-xl">
         <div className="mb-4 flex items-center gap-3">
           <div className="rounded-full bg-sky-500/20 p-2">
@@ -196,7 +193,17 @@ export function ShareExpenseForm({
                 type="email"
                 placeholder="Enter email address"
                 value={newEmail}
-                onChange={(e) => setNewEmail(e.target.value)}
+                error={!!emailError}
+                aria-describedby={emailError ? 'email-error' : undefined}
+                onChange={(e) => {
+                  setNewEmail(e.target.value)
+                  if (emailError) setEmailError(null)
+                }}
+                onBlur={() => {
+                  if (newEmail.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newEmail.trim())) {
+                    setEmailError('Enter a valid email address')
+                  }
+                }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     e.preventDefault()
@@ -204,6 +211,11 @@ export function ShareExpenseForm({
                   }
                 }}
               />
+              {emailError && (
+                <p id="email-error" className="text-xs text-rose-300">
+                  {emailError}
+                </p>
+              )}
               <Button
                 type="button"
                 variant="secondary"
@@ -314,7 +326,12 @@ export function ShareExpenseForm({
             <Button type="button" variant="outline" className="flex-1" onClick={onClose} disabled={isPending}>
               Cancel
             </Button>
-            <Button type="submit" className="flex-1" loading={isPending} disabled={participants.length === 0 || isPending}>
+            <Button
+              type="submit"
+              className="flex-1"
+              loading={isPending}
+              disabled={participants.length === 0 || isPending}
+            >
               Share expense
             </Button>
           </div>

--- a/src/components/dashboard/share-expense-form.tsx
+++ b/src/components/dashboard/share-expense-form.tsx
@@ -61,6 +61,12 @@ export function ShareExpenseForm({
 
     const email = newEmail.trim().toLowerCase()
 
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('Enter a valid email address')
+      return
+    }
+    setEmailError(null)
+
     if (participants.some((p) => p.email.toLowerCase() === email)) {
       toast.error('This person is already added')
       return
@@ -212,7 +218,7 @@ export function ShareExpenseForm({
                 }}
               />
               {emailError && (
-                <p id="email-error" className="text-xs text-rose-300">
+                <p id="email-error" role="alert" className="text-xs text-rose-300">
                   {emailError}
                 </p>
               )}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,16 +1,25 @@
 import React from 'react'
 import { cn } from '@/utils/cn'
 
-type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  error?: boolean
+  valid?: boolean
+}
 
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, error, valid, 'aria-invalid': ariaInvalid, ...props }, ref) => {
     return (
       <textarea
         ref={ref}
+        aria-invalid={ariaInvalid ?? (error ? 'true' : undefined)}
         className={cn(
-          'block w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-slate-950/20 backdrop-blur focus:outline-none',
-          'placeholder:text-slate-400 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-400/40 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-slate-400',
+          'block w-full rounded-lg border bg-white/10 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-slate-950/20 backdrop-blur focus:outline-none',
+          'placeholder:text-slate-400 transition disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-slate-400',
+          error
+            ? 'border-rose-400 focus:border-rose-400 focus:ring-2 focus:ring-rose-400/40'
+            : valid
+              ? 'border-emerald-400 focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40'
+              : 'border-white/20 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/40',
           className,
         )}
         {...props}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -16,11 +16,12 @@ if (!DATABASE_URL) {
   throw new Error('DATABASE_URL is not set')
 }
 
+const poolMax = Math.max(1, Number(process.env.DB_POOL_MAX) || 10)
 const pool =
   global.prismaPool ??
   new Pool({
     connectionString: DATABASE_URL,
-    max: parseInt(process.env.DB_POOL_MAX || '10', 10),
+    max: poolMax,
     idleTimeoutMillis: 30_000,
   })
 const adapter = new PrismaPg(pool)

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -16,7 +16,13 @@ if (!DATABASE_URL) {
   throw new Error('DATABASE_URL is not set')
 }
 
-const pool = global.prismaPool ?? new Pool({ connectionString: DATABASE_URL })
+const pool =
+  global.prismaPool ??
+  new Pool({
+    connectionString: DATABASE_URL,
+    max: parseInt(process.env.DB_POOL_MAX || '10', 10),
+    idleTimeoutMillis: 30_000,
+  })
 const adapter = new PrismaPg(pool)
 
 const basePrisma = new PrismaClient({

--- a/tests/auth-actions.test.ts
+++ b/tests/auth-actions.test.ts
@@ -925,8 +925,8 @@ describe('auth actions', () => {
       expect(prisma.$transaction).toHaveBeenCalledTimes(1)
       const transactionArg = vi.mocked(prisma.$transaction).mock.calls[0][0]
       expect(Array.isArray(transactionArg)).toBe(true)
-      // Should have 8 delete operations: transactionRequest, transaction, holding, budget, recurringTemplate, monthlyIncomeGoal, dashboardCache, user
-      expect(transactionArg).toHaveLength(8)
+      // Should have 9 operations: sharedExpense soft-delete, transactionRequest, transaction, holding, budget, recurringTemplate, monthlyIncomeGoal, dashboardCache, user
+      expect(transactionArg).toHaveLength(9)
     })
 
     it('requires valid CSRF token', async () => {

--- a/tests/auth-actions.test.ts
+++ b/tests/auth-actions.test.ts
@@ -38,6 +38,9 @@ vi.mock('@/lib/prisma', () => ({
     monthlyIncomeGoal: {
       deleteMany: vi.fn(),
     },
+    sharedExpense: {
+      updateMany: vi.fn(),
+    },
     dashboardCache: {
       deleteMany: vi.fn(),
     },


### PR DESCRIPTION
## Summary
Addresses 5 remaining items from the multi-agent audit.

## Changes

| Finding | Severity | Fix |
|---------|----------|-----|
| M8 | medium | Add explicit `max`/`idleTimeoutMillis` to pg Pool constructor |
| M12 | medium | Add `error`/`valid` props to Textarea component (matching Input pattern) |
| M3 | medium | Soft-delete pending shared expenses before GDPR account deletion |
| H4 | high | Add retry button to chat widget when network error occurs |
| M13 | medium | Add blur-based email validation on share expense form input |

## Test plan
- [x] 2275 tests pass
- [x] TypeScript clean
- [x] Lint clean