### PR TITLE
perf: wrap dashboard tab components in React.memo

### DIFF
--- a/src/components/dashboard/tabs/budgets-tab.tsx
+++ b/src/components/dashboard/tabs/budgets-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState, useTransition, useCallback, useRef } from 'react'
+import { memo, useEffect, useMemo, useState, useTransition, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { TransactionType, Currency } from '@prisma/client'
 import { Target } from 'lucide-react'
@@ -33,7 +33,7 @@ export type BudgetsTabProps = {
   actualIncome?: number
 }
 
-export function BudgetsTab({
+export const BudgetsTab = memo(function BudgetsTab({
   budgets,
   accounts,
   categories,
@@ -640,4 +640,4 @@ export function BudgetsTab({
       </Card>
     </div>
   )
-}
+})

--- a/src/components/dashboard/tabs/categories-tab.tsx
+++ b/src/components/dashboard/tabs/categories-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState, useTransition } from 'react'
+import { memo, useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { TransactionType } from '@prisma/client'
 import { Tags } from 'lucide-react'
@@ -20,7 +20,7 @@ export type CategoriesTabProps = {
   categories: DashboardCategory[]
 }
 
-export function CategoriesTab({ categories }: CategoriesTabProps) {
+export const CategoriesTab = memo(function CategoriesTab({ categories }: CategoriesTabProps) {
   const router = useRouter()
   const csrfToken = useCsrfToken()
 
@@ -304,4 +304,4 @@ export function CategoriesTab({ categories }: CategoriesTabProps) {
       </div>
     </div>
   )
-}
+})

--- a/src/components/dashboard/tabs/overview-tab.tsx
+++ b/src/components/dashboard/tabs/overview-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { TransactionType, Currency } from '@prisma/client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -26,7 +26,7 @@ export type OverviewTabProps = {
   onNavigateToBudgets: () => void
 }
 
-export function OverviewTab({
+export const OverviewTab = memo(function OverviewTab({
   history,
   comparison,
   budgets,
@@ -212,4 +212,4 @@ export function OverviewTab({
       )}
     </div>
   )
-}
+})

--- a/src/components/dashboard/tabs/recurring-tab.tsx
+++ b/src/components/dashboard/tabs/recurring-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState, useTransition } from 'react'
+import { memo, useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { TransactionType, Currency } from '@prisma/client'
 import { Repeat } from 'lucide-react'
@@ -40,7 +40,7 @@ export type RecurringTabProps = {
   preferredCurrency: Currency
 }
 
-export function RecurringTab({
+export const RecurringTab = memo(function RecurringTab({
   recurringTemplates,
   accounts,
   categories,
@@ -508,4 +508,4 @@ export function RecurringTab({
       </div>
     </div>
   )
-}
+})

--- a/src/components/dashboard/tabs/sharing-tab.tsx
+++ b/src/components/dashboard/tabs/sharing-tab.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { memo } from 'react'
 import { SharedExpensesList } from '@/components/dashboard/shared-expenses-list'
 import { ExpensesSharedWithMe } from '@/components/dashboard/expenses-shared-with-me'
 import { SettlementSummary } from '@/components/dashboard/settlement-summary'
@@ -17,7 +18,7 @@ export type SharingTabProps = {
   paymentHistory: PaymentHistoryItem[]
 }
 
-export function SharingTab({
+export const SharingTab = memo(function SharingTab({
   sharedExpenses,
   expensesSharedWithMe,
   settlementBalances,
@@ -33,4 +34,4 @@ export function SharingTab({
       </div>
     </div>
   )
-}
+})

--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { TransactionType, Currency } from '@prisma/client'
 import { Download, Users, Pencil, Trash2, Receipt } from 'lucide-react'
@@ -45,7 +45,7 @@ export type TransactionsTabProps = {
   preferredCurrency: Currency
 }
 
-export function TransactionsTab({
+export const TransactionsTab = memo(function TransactionsTab({
   transactions,
   transactionRequests,
   accounts,
@@ -804,4 +804,4 @@ export function TransactionsTab({
       )}
     </div>
   )
-}
+})


### PR DESCRIPTION
## Summary
Wrap all 6 dashboard tab components in `React.memo` to prevent unnecessary re-renders when switching between tabs or when parent dashboard state changes.

## Components memoized
- `BudgetsTab` (643 lines)
- `TransactionsTab` (807 lines)
- `OverviewTab` (215 lines)
- `CategoriesTab` (307 lines)
- `SharingTab` (37 lines)
- `RecurringTab` (511 lines)

## Why
When the dashboard re-renders (month navigation, account selection, keyboard shortcuts), ALL tab components re-render even though only the active tab is visible. With memo, inactive tabs skip re-rendering when their props haven't changed.

## Test plan
- [x] 2275 tests pass
- [x] TypeScript clean
- [x] Lint clean