### PR TITLE
refactor: extract soft-delete to shared utility, close remaining audit items

### DIFF
--- a/src/app/actions/account.ts
+++ b/src/app/actions/account.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { clearSession, updateSessionAccount } from '@/lib/auth-server'
 import { success, successVoid, failure, generalError } from '@/lib/action-result'
-import { parseInput, ensureAccountAccess, requireCsrfToken, requireAuthUser } from './shared'
+import { parseInput, ensureAccountAccess, requireCsrfToken, requireAuthUser, softDeleteData } from './shared'
 import { checkRateLimitTyped, incrementRateLimitTyped } from '@/lib/rate-limit'
 import { serverLogger } from '@/lib/server-logger'
 import { accountSelectionSchema, deleteAccountSchema, exportUserDataSchema } from '@/schemas'
@@ -79,7 +79,7 @@ export async function deleteAccountAction(input: z.infer<typeof deleteAccountSch
     deleteOps.push(
       prisma.sharedExpense.updateMany({
         where: { ownerId: authUser.id, deletedAt: null },
-        data: { deletedAt: new Date(), deletedBy: authUser.id },
+        data: softDeleteData(authUser.id),
       }),
     )
 

--- a/src/app/actions/accounts.ts
+++ b/src/app/actions/accounts.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { successVoid, generalError } from '@/lib/action-result'
 import { handlePrismaError } from '@/lib/prisma-errors'
-import { parseInput, requireCsrfToken, requireAuthUser } from './shared'
+import { parseInput, requireCsrfToken, requireAuthUser, softDeleteData } from './shared'
 import { deleteFinancialAccountSchema } from '@/schemas'
 import { invalidateDashboardCache } from '@/lib/dashboard-cache'
 import { getMonthKey } from '@/utils/date'
@@ -69,7 +69,7 @@ export async function deleteFinancialAccountAction(input: z.infer<typeof deleteF
   try {
     await prisma.account.update({
       where: { id: parsed.data.accountId },
-      data: { deletedAt: new Date(), deletedBy: authUser.id },
+      data: softDeleteData(authUser.id),
     })
 
     // Invalidate dashboard cache for all months (account deletion affects all historical data)

--- a/src/app/actions/budgets.ts
+++ b/src/app/actions/budgets.ts
@@ -7,7 +7,13 @@ import { prisma } from '@/lib/prisma'
 import { getMonthStartFromKey } from '@/utils/date'
 import { successVoid } from '@/lib/action-result'
 import { handlePrismaError } from '@/lib/prisma-errors'
-import { parseInput, toDecimalString, ensureAccountAccessWithSubscription, requireCsrfToken } from './shared'
+import {
+  parseInput,
+  toDecimalString,
+  ensureAccountAccessWithSubscription,
+  requireCsrfToken,
+  softDeleteData,
+} from './shared'
 import {
   budgetSchema,
   deleteBudgetSchema,
@@ -103,10 +109,7 @@ export async function deleteBudgetAction(input: z.infer<typeof deleteBudgetSchem
         },
         deletedAt: null, // Only delete non-deleted budgets
       },
-      data: {
-        deletedAt: new Date(),
-        deletedBy: authUser.id,
-      },
+      data: softDeleteData(authUser.id),
     })
 
     // Invalidate dashboard cache for affected month/account
@@ -223,10 +226,7 @@ export async function deleteMonthlyIncomeGoalAction(input: z.infer<typeof delete
         },
         deletedAt: null,
       },
-      data: {
-        deletedAt: new Date(),
-        deletedBy: authUser.id,
-      },
+      data: softDeleteData(authUser.id),
     })
 
     await invalidateDashboardCache({

--- a/src/app/actions/holdings.ts
+++ b/src/app/actions/holdings.ts
@@ -6,7 +6,13 @@ import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { success, successVoid, failure, generalError } from '@/lib/action-result'
 import { handlePrismaError } from '@/lib/prisma-errors'
-import { parseInput, toDecimalString, ensureAccountAccessWithSubscription, requireCsrfToken } from './shared'
+import {
+  parseInput,
+  toDecimalString,
+  ensureAccountAccessWithSubscription,
+  requireCsrfToken,
+  softDeleteData,
+} from './shared'
 import { invalidateDashboardCache } from '@/lib/dashboard-cache'
 import {
   holdingSchema,
@@ -185,10 +191,7 @@ export async function deleteHoldingAction(input: z.infer<typeof deleteHoldingSch
   try {
     await prisma.holding.update({
       where: { id: parsed.data.id },
-      data: {
-        deletedAt: new Date(),
-        deletedBy: access.authUser.id,
-      },
+      data: softDeleteData(access.authUser.id),
     })
 
     // Invalidate dashboard cache for this account (holdings affect portfolio value across all months)

--- a/src/app/actions/recurring.ts
+++ b/src/app/actions/recurring.ts
@@ -8,7 +8,13 @@ import { getMonthStartFromKey } from '@/utils/date'
 import { getDaysInMonth } from 'date-fns'
 import { success, successVoid, failure, generalError } from '@/lib/action-result'
 import { handlePrismaError } from '@/lib/prisma-errors'
-import { parseInput, toDecimalString, ensureAccountAccessWithSubscription, requireCsrfToken } from './shared'
+import {
+  parseInput,
+  toDecimalString,
+  ensureAccountAccessWithSubscription,
+  requireCsrfToken,
+  softDeleteData,
+} from './shared'
 import { invalidateDashboardCache } from '@/lib/dashboard-cache'
 import {
   recurringTemplateSchema,
@@ -251,10 +257,7 @@ export async function deleteRecurringTemplateAction(input: z.infer<typeof delete
   try {
     await prisma.recurringTemplate.update({
       where: { id: parsed.data.id },
-      data: {
-        deletedAt: new Date(),
-        deletedBy: authUser.id,
-      },
+      data: softDeleteData(authUser.id),
     })
   } catch (error) {
     return handlePrismaError(error, {

--- a/src/app/actions/shared.ts
+++ b/src/app/actions/shared.ts
@@ -38,6 +38,11 @@ import { hasActiveSubscription, getSubscriptionState, type SubscriptionState } f
 // Re-export from utils for backwards compatibility with actions
 export { toDecimalString } from '@/utils/decimal'
 
+/** Soft-delete data payload. Use in Prisma update `data` field. */
+export function softDeleteData(userId: string) {
+  return { deletedAt: new Date(), deletedBy: userId }
+}
+
 export function parseInput<T>(
   schema: z.ZodSchema<T>,
   input: unknown,

--- a/src/app/actions/transactions.ts
+++ b/src/app/actions/transactions.ts
@@ -13,6 +13,7 @@ import {
   ensureAccountAccessWithSubscription,
   requireCsrfToken,
   requireActiveSubscription,
+  softDeleteData,
 } from './shared'
 import { invalidateDashboardCache } from '@/lib/dashboard-cache'
 import {
@@ -565,7 +566,7 @@ export async function deleteTransactionAction(input: z.infer<typeof deleteTransa
   try {
     await prisma.transaction.update({
       where: { id: parsed.data.id },
-      data: { deletedAt: new Date(), deletedBy: authUser.id },
+      data: softDeleteData(authUser.id),
     })
 
     // Invalidate dashboard cache for affected month/account

--- a/tests/auth-actions.test.ts
+++ b/tests/auth-actions.test.ts
@@ -99,6 +99,7 @@ vi.mock('@/app/actions/shared', () => ({
   }),
   requireCsrfToken: vi.fn().mockResolvedValue({ success: true }),
   requireAuthUser: vi.fn(),
+  softDeleteData: (userId: string) => ({ deletedAt: new Date(), deletedBy: userId }),
 }))
 
 import { verifyCredentials, establishSession, clearSession, updateSessionAccount } from '@/lib/auth-server'


### PR DESCRIPTION
## Summary
Final audit cleanup — extracts the repeated soft-delete pattern to a shared utility and closes out all remaining actionable audit items.

## Changes

### Soft-delete extraction (M17)
- New `softDeleteData(userId)` function in `src/app/actions/shared.ts`
- Replaces 7 inline `{ deletedAt: new Date(), deletedBy: userId }` patterns across 6 action files
- Single source of truth for the soft-delete data payload

### Deferred items — intentionally not fixed
| Item | Reason |
|------|--------|
| TransactionRequest soft delete (H5) | Model uses `status` field (PENDING/APPROVED/REJECTED) instead — adding deletedAt would create duplicate deletion mechanisms |
| Prop drilling → Context (M16) | Dashboard props are clean and explicit; Context adds indirection without clear benefit |
| Rate limiting Redis (M11) | Infrastructure decision — requires deployment platform choice |

## Test plan
- [x] 2275 tests pass
- [x] TypeScript clean
- [x] Lint clean