### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack vulnerability in cron endpoints

### DIFF
--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { serverLogger } from '@/lib/server-logger'
@@ -32,7 +33,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
   }
 
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  // Mitigate timing attacks by using crypto.timingSafeEqual
+  let isAuthorized = false
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const providedSecret = authHeader.substring(7)
+    if (providedSecret.length === cronSecret.length) {
+      isAuthorized = crypto.timingSafeEqual(Buffer.from(providedSecret), Buffer.from(cronSecret))
+    }
+  }
+
+  if (!isAuthorized) {
     serverLogger.warn('Cron cleanup: unauthorized access attempt', {
       action: 'cron.cleanup',
       clientIp,

--- a/src/app/api/cron/subscriptions/route.ts
+++ b/src/app/api/cron/subscriptions/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { processExpiredSubscriptions } from '@/lib/subscription'
 import { serverLogger } from '@/lib/server-logger'
@@ -29,7 +30,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
   }
 
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  // Mitigate timing attacks by using crypto.timingSafeEqual
+  let isAuthorized = false
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const providedSecret = authHeader.substring(7)
+    if (providedSecret.length === cronSecret.length) {
+      isAuthorized = crypto.timingSafeEqual(Buffer.from(providedSecret), Buffer.from(cronSecret))
+    }
+  }
+
+  if (!isAuthorized) {
     serverLogger.warn('Cron subscription expiration: unauthorized access attempt', {
       action: 'cron.subscriptions',
       clientIp,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `cleanup` and `subscriptions` cron endpoints used simple string inequality (`!==`) to compare the incoming `CRON_SECRET` bearer token against the expected secret. This creates a timing attack vulnerability where an attacker could theoretically guess the secret character by character by measuring minute differences in response times, as `!==` returns false immediately upon the first mismatched character.
🎯 Impact: An attacker could guess the `CRON_SECRET` and execute unauthorized cleanup tasks or expire subscriptions prematurely, potentially causing data inconsistency or business logic disruption.
🔧 Fix: Replaced the standard string comparison with a constant-time comparison using `node:crypto.timingSafeEqual`. To prevent `timingSafeEqual` from throwing an error if the strings are different lengths (which itself leaks length information), it first checks if the lengths match before comparing.
✅ Verification: `pnpm lint` and `pnpm check-types` pass. The endpoints maintain functionality and will now execute validation in constant time regardless of where a mismatch occurs in the token.

---
*PR created automatically by Jules for task [545760864882850587](https://jules.google.com/task/545760864882850587) started by @avifenesh*