### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unhashed password reset tokens in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Login endpoint exposed user existence via response time difference (bcrypt comparison vs immediate return).
 **Learning:** `verifyCredentials` checked user existence before verifying password, allowing ~100ms timing difference.
 **Prevention:** Use constant-time comparison logic. Always perform `bcrypt.compare` even if user is not found, using a pre-computed dummy hash.
+## 2026-03-11 - Hashing Password Reset Tokens
+**Vulnerability:** Password reset tokens were stored in plaintext in the database, allowing an attacker with DB access to reset passwords and hijack accounts.
+**Learning:** Raw tokens were stored instead of cryptographic hashes. While random, they act as equivalent to a temporary password, thus should be treated similarly.
+**Prevention:** Always use `crypto.createHash('sha256')` to hash randomly generated tokens before database insertion, and hash incoming tokens before database querying.

--- a/src/app/api/v1/auth/request-reset/route.ts
+++ b/src/app/api/v1/auth/request-reset/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { randomBytes } from 'crypto'
+import crypto, { randomBytes } from 'crypto'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { consumeRateLimit } from '@/lib/rate-limit'
@@ -46,13 +46,15 @@ export async function POST(request: NextRequest) {
 
     // Generate reset token
     const resetToken = randomBytes(32).toString('hex')
+    // Hash token before storing (security best practice - prevents token theft if DB is compromised)
+    const hashedToken = crypto.createHash('sha256').update(resetToken).digest('hex')
     const resetExpires = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
 
     // Update user with reset token
     await prisma.user.update({
       where: { id: user.id },
       data: {
-        passwordResetToken: resetToken,
+        passwordResetToken: hashedToken,
         passwordResetExpires: resetExpires,
       },
     })

--- a/src/app/api/v1/auth/reset-password/route.ts
+++ b/src/app/api/v1/auth/reset-password/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import crypto from 'crypto'
 import bcrypt from 'bcryptjs'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
@@ -32,9 +33,12 @@ export async function POST(request: NextRequest) {
 
     const { token, newPassword } = parsed.data
 
+    // Hash the incoming token to compare with stored hash
+    const hashedToken = crypto.createHash('sha256').update(token).digest('hex')
+
     // Find user with this reset token
     const user = await prisma.user.findUnique({
-      where: { passwordResetToken: token },
+      where: { passwordResetToken: hashedToken },
     })
 
     if (!user) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Password reset tokens were stored as plaintext in the database (via `passwordResetToken`). A database leak would allow attackers to intercept valid tokens and change user passwords.
🎯 **Impact:** Account takeover if database is compromised.
🔧 **Fix:** Imported `crypto` and updated the `request-reset` route to hash the `resetToken` using `SHA-256` prior to saving. Updated the `reset-password` route to similarly hash the incoming token for lookup comparison.
✅ **Verification:** Verify that requesting a reset sends the plain token via email but stores a hashed string in the `passwordResetToken` database field. Also ensure the reset functionality succeeds with the valid token.

---
*PR created automatically by Jules for task [10130658572703653471](https://jules.google.com/task/10130658572703653471) started by @avifenesh*