### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace insecure Math.random for ID generation

### DIFF
--- a/src/components/ai/chat-utils.ts
+++ b/src/components/ai/chat-utils.ts
@@ -23,8 +23,9 @@ export function createTitleFromMessage(message: Message | undefined): string | n
 }
 
 export function createSession(title: string, isCustomTitle = false): ChatSession {
+  // Sentinel: Use crypto.getRandomValues instead of Math.random for secure fallback ID generation
   return {
-    id: crypto.randomUUID?.() ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    id: crypto.randomUUID?.() ?? `session-${Date.now()}-${crypto.getRandomValues(new Uint32Array(1))[0].toString(36).padStart(7, '0')}`,
     title,
     messages: [],
     createdAt: new Date().toISOString(),
@@ -55,7 +56,8 @@ export function loadSessionsFromStorage(storageKey: string): ChatSession[] {
 }
 
 export function generateMessageId(): string {
-  return crypto.randomUUID?.() ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  // Sentinel: Use crypto.getRandomValues instead of Math.random for secure fallback ID generation
+  return crypto.randomUUID?.() ?? `msg-${Date.now()}-${crypto.getRandomValues(new Uint32Array(1))[0].toString(36).padStart(7, '0')}`
 }
 
 export const quickPrompts = [


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** `Math.random()` was being used as a fallback to generate session and message IDs, which isn't cryptographically secure and can lead to predictable IDs.
**🎯 Impact:** While these are primarily UI IDs, using predictable IDs can theoretically allow session or message spoofing/collision in certain edge cases, violating the defense-in-depth principle.
**🔧 Fix:** Replaced `Math.random().toString(36).slice(2, 8)` with `crypto.getRandomValues(new Uint32Array(1))[0].toString(36).padStart(7, '0')`. `crypto.randomUUID?.()` already verifies `crypto` exists globally.
**✅ Verification:** `pnpm lint` and `pnpm test` pass. Evaluated the fix to ensure it falls under the 50 lines boundary without polluting the `pnpm-lock.yaml`.

---
*PR created automatically by Jules for task [12665603062295240886](https://jules.google.com/task/12665603062295240886) started by @avifenesh*