### PR TITLE
🎨 Palette: Add keyboard focus states to Quick Action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-19 - Add explicit focus-visible classes and type attribute to raw <button> tags
+**Learning:** Raw inline `<button>` tags added ad-hoc often miss standard keyboard accessibility (like visible focus rings) and functional attributes (`type="button"`). This can cause screen reader issues, keyboard navigation dead ends, and unintended form submissions.
+**Action:** When creating raw `<button>` elements, always explicitly define `type="button"` and ensure standard tailwind `focus-visible:` accessibility styles (e.g. `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950`) are present to match the overall design system focus rings.

--- a/src/components/dashboard/dashboard-page.tsx
+++ b/src/components/dashboard/dashboard-page.tsx
@@ -820,22 +820,25 @@ export function DashboardPage({ data, monthKey, accountId, subscription, userEma
             {/* Quick Actions */}
             <div className="flex gap-2 flex-wrap">
               <button
+                type="button"
                 onClick={() => handleTabChange('transactions')}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 <Plus className="h-3.5 w-3.5" />
                 Add Transaction
               </button>
               <button
+                type="button"
                 onClick={() => handleTabChange('budgets')}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 <Target className="h-3.5 w-3.5" />
                 Set Budget
               </button>
               <button
+                type="button"
                 onClick={() => handleTabChange('recurring')}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 <RefreshCw className="h-3.5 w-3.5" />
                 Recurring


### PR DESCRIPTION
💡 What: Added `type="button"` and `focus-visible` ring Tailwind utility classes to the three inline "Quick Action" buttons on the Dashboard overview tab.
🎯 Why: Raw `<button>` tags lacked visual focus rings for keyboard navigation compared to the rest of the app's components, and missing `type="button"` is poor practice.
📸 Before/After: Visual focus states are now identical to the rest of the application's components.
♿ Accessibility: Ensures full keyboard accessibility and visual consistency for interactive elements. Recorded learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [872707906410426226](https://jules.google.com/task/872707906410426226) started by @avifenesh*