### PR TITLE
🛡️ Sentinel: [HIGH] Fix password reset token hashing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Login endpoint exposed user existence via response time difference (bcrypt comparison vs immediate return).
 **Learning:** `verifyCredentials` checked user existence before verifying password, allowing ~100ms timing difference.
 **Prevention:** Use constant-time comparison logic. Always perform `bcrypt.compare` even if user is not found, using a pre-computed dummy hash.
+
+## 2026-03-16 - Unhashed Password Reset Tokens
+**Vulnerability:** Password reset tokens were stored in plaintext in the database.
+**Learning:** Generating tokens with `randomBytes` and storing them as-is allows anyone with DB access to reset passwords.
+**Prevention:** Always hash sensitive tokens using `crypto.createHash('sha256')` before storing them, and hash incoming tokens before lookup.

--- a/src/app/api/v1/auth/request-reset/route.ts
+++ b/src/app/api/v1/auth/request-reset/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { randomBytes } from 'crypto'
+import { randomBytes, createHash } from 'crypto'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { consumeRateLimit } from '@/lib/rate-limit'
@@ -46,13 +46,16 @@ export async function POST(request: NextRequest) {
 
     // Generate reset token
     const resetToken = randomBytes(32).toString('hex')
+
+    // Hash the token before storing to prevent account takeover if the database is compromised
+    const hashedToken = createHash('sha256').update(resetToken).digest('hex')
     const resetExpires = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
 
     // Update user with reset token
     await prisma.user.update({
       where: { id: user.id },
       data: {
-        passwordResetToken: resetToken,
+        passwordResetToken: hashedToken,
         passwordResetExpires: resetExpires,
       },
     })

--- a/src/app/api/v1/auth/reset-password/route.ts
+++ b/src/app/api/v1/auth/reset-password/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import bcrypt from 'bcryptjs'
+import { createHash } from 'crypto'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { validationError, successResponse, serverError, authError } from '@/lib/api-helpers'
@@ -32,9 +33,12 @@ export async function POST(request: NextRequest) {
 
     const { token, newPassword } = parsed.data
 
+    // Hash the incoming token to compare with the stored hash to prevent account takeover if the database is compromised
+    const hashedToken = createHash('sha256').update(token).digest('hex')
+
     // Find user with this reset token
     const user = await prisma.user.findUnique({
-      where: { passwordResetToken: token },
+      where: { passwordResetToken: hashedToken },
     })
 
     if (!user) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Password reset tokens were generated and stored in plaintext in the database via the API endpoints. If an attacker gains read access to the database, they could use these valid tokens to reset passwords and take over user accounts.
🎯 Impact: Full account takeover for any user with an active reset token.
🔧 Fix: Used `crypto.createHash('sha256')` to hash the token before storing it in `src/app/api/v1/auth/request-reset/route.ts`, and added hashing to the incoming token before lookup in `src/app/api/v1/auth/reset-password/route.ts`. Added comments explaining the security concern.
✅ Verification: Ran unit tests (`pnpm test tests/api/v1/auth-password-reset.test.ts`) which passed, confirming the behavior remains functionally equivalent while being more secure.

---
*PR created automatically by Jules for task [6314622477574412170](https://jules.google.com/task/6314622477574412170) started by @avifenesh*