### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix timing attack in cron endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Login endpoint exposed user existence via response time difference (bcrypt comparison vs immediate return).
 **Learning:** `verifyCredentials` checked user existence before verifying password, allowing ~100ms timing difference.
 **Prevention:** Use constant-time comparison logic. Always perform `bcrypt.compare` even if user is not found, using a pre-computed dummy hash.
+
+## 2025-02-14 - Timing Attack on Cron Secret Authorization
+**Vulnerability:** Cron endpoints (`/api/cron/subscriptions` and `/api/cron/cleanup`) used string comparison (`!==`) to verify the `CRON_SECRET` authorization header.
+**Learning:** Standard string comparisons can exit early on the first mismatched character, allowing attackers to guess the secret character by character by measuring response times.
+**Prevention:** Use `crypto.timingSafeEqual` for comparing secrets or tokens. Ensure both the expected and provided values are converted to `Buffer` objects and verify they share the exact same byte length (`Buffer.length`) before calling `timingSafeEqual` to avoid throwing errors on length mismatches.

--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { serverLogger } from '@/lib/server-logger'
@@ -32,7 +33,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
   }
 
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  // Security: Use constant-time comparison to prevent timing attacks
+  const expectedAuth = Buffer.from(`Bearer ${cronSecret}`)
+  const providedAuth = Buffer.from(authHeader || '')
+
+  if (expectedAuth.length !== providedAuth.length || !crypto.timingSafeEqual(expectedAuth, providedAuth)) {
     serverLogger.warn('Cron cleanup: unauthorized access attempt', {
       action: 'cron.cleanup',
       clientIp,

--- a/src/app/api/cron/subscriptions/route.ts
+++ b/src/app/api/cron/subscriptions/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { processExpiredSubscriptions } from '@/lib/subscription'
 import { serverLogger } from '@/lib/server-logger'
@@ -29,7 +30,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
   }
 
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  // Security: Use constant-time comparison to prevent timing attacks
+  const expectedAuth = Buffer.from(`Bearer ${cronSecret}`)
+  const providedAuth = Buffer.from(authHeader || '')
+
+  if (expectedAuth.length !== providedAuth.length || !crypto.timingSafeEqual(expectedAuth, providedAuth)) {
     serverLogger.warn('Cron subscription expiration: unauthorized access attempt', {
       action: 'cron.subscriptions',
       clientIp,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The cron endpoints (`/api/cron/subscriptions/route.ts` and `/api/cron/cleanup/route.ts`) were verifying the `CRON_SECRET` authorization header using a standard string comparison (`!==`).
🎯 Impact: Standard string comparisons can exit early on the first mismatched character. This theoretical timing difference could allow an attacker to guess the secret character by character by measuring the response time of the server.
🔧 Fix: Replaced string comparison with a constant-time comparison using `crypto.timingSafeEqual()`. Added logic to convert inputs to buffers and to check that they have equal byte lengths before the constant-time comparison, to prevent length mismatch errors from crashing the app.
✅ Verification: Ran `pnpm test` successfully. Verified that `crypto.timingSafeEqual` prevents timing attacks safely. Logged the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1023552008692368357](https://jules.google.com/task/1023552008692368357) started by @avifenesh*