### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-20 - Missing focus states on raw buttons
+**Learning:** Raw `<button>` tags scattered throughout the app without leveraging the standard `<Button>` component are frequently missing focus-visible classes, making them invisible to keyboard navigation users.
+**Action:** When adding or auditing raw button elements, ensure explicit focus styles (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950`) are applied to maintain keyboard accessibility.

--- a/src/components/dashboard/dashboard-page.tsx
+++ b/src/components/dashboard/dashboard-page.tsx
@@ -735,7 +735,7 @@ export function DashboardPage({ data, monthKey, accountId, subscription, userEma
                 key={stat.label}
                 type="button"
                 onClick={() => setExpandedStat(isExpanded ? null : stat.label)}
-                className={cn(cardClassName, 'cursor-pointer hover:bg-white/10 text-left')}
+                className={cn(cardClassName, 'cursor-pointer hover:bg-white/10 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950')}
                 aria-expanded={isExpanded}
                 aria-controls={`stat-breakdown-${stat.label.replace(/\s+/g, '-').toLowerCase()}`}
                 aria-label={`View ${stat.label} breakdown`}
@@ -767,7 +767,7 @@ export function DashboardPage({ data, monthKey, accountId, subscription, userEma
                   <button
                     type="button"
                     onClick={() => setExpandedStat(null)}
-                    className="text-xs text-slate-400 hover:text-white transition"
+                    className="text-xs text-slate-400 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-1"
                     aria-label="Close breakdown"
                   >
                     Close
@@ -821,21 +821,21 @@ export function DashboardPage({ data, monthKey, accountId, subscription, userEma
             <div className="flex gap-2 flex-wrap">
               <button
                 onClick={() => handleTabChange('transactions')}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 <Plus className="h-3.5 w-3.5" />
                 Add Transaction
               </button>
               <button
                 onClick={() => handleTabChange('budgets')}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 <Target className="h-3.5 w-3.5" />
                 Set Budget
               </button>
               <button
                 onClick={() => handleTabChange('recurring')}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 border border-white/15 hover:bg-white/15 text-sm text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 <RefreshCw className="h-3.5 w-3.5" />
                 Recurring

--- a/src/components/dashboard/holdings-tab.tsx
+++ b/src/components/dashboard/holdings-tab.tsx
@@ -332,7 +332,7 @@ export default function HoldingsTab({
                     ?.closest('form')
                     ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                 }
-                className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                className="text-sm text-sky-400 hover:text-sky-300 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-2 py-1"
               >
                 Add your first holding →
               </button>
@@ -369,7 +369,7 @@ export default function HoldingsTab({
                     onClick={() => handleDeleteRequest(holding.id, holding.symbol)}
                     disabled={isPendingAction || deletingId === holding.id}
                     className={cn(
-                      'text-xs text-rose-400 transition hover:text-rose-300',
+                      'text-xs text-rose-400 transition hover:text-rose-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-1',
                       (isPendingAction || deletingId === holding.id) && 'opacity-50 cursor-not-allowed',
                     )}
                   >

--- a/src/components/dashboard/shared-expenses-list.tsx
+++ b/src/components/dashboard/shared-expenses-list.tsx
@@ -93,7 +93,7 @@ export function SharedExpensesList({ sharedExpenses }: SharedExpensesListProps) 
             <div key={expense.id} className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
               <button
                 type="button"
-                className="flex w-full items-center justify-between p-4 text-left hover:bg-white/5 transition"
+                className="flex w-full items-center justify-between p-4 text-left hover:bg-white/5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-xl"
                 onClick={() => setExpandedId(isExpanded ? null : expense.id)}
                 aria-expanded={isExpanded}
                 aria-controls={`details-${expense.id}`}

--- a/src/components/dashboard/tabs/budgets-tab.tsx
+++ b/src/components/dashboard/tabs/budgets-tab.tsx
@@ -312,7 +312,7 @@ export function BudgetsTab({
                       onClick={() =>
                         document.getElementById('budget-form')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                       }
-                      className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                      className="text-sm text-sky-400 hover:text-sky-300 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-2 py-1"
                     >
                       Add your first budget →
                     </button>

--- a/src/components/dashboard/tabs/categories-tab.tsx
+++ b/src/components/dashboard/tabs/categories-tab.tsx
@@ -240,7 +240,7 @@ export function CategoriesTab({ categories }: CategoriesTabProps) {
                           .getElementById('category-form')
                           ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                       }
-                      className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                      className="text-sm text-sky-400 hover:text-sky-300 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-2 py-1"
                     >
                       Add your first category →
                     </button>

--- a/src/components/dashboard/tabs/recurring-tab.tsx
+++ b/src/components/dashboard/tabs/recurring-tab.tsx
@@ -372,7 +372,7 @@ export function RecurringTab({
                             .getElementById('recurring-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                        className="text-sm text-sky-400 hover:text-sky-300 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-2 py-1"
                       >
                         Add your first template →
                       </button>

--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -692,7 +692,7 @@ export function TransactionsTab({
                             .getElementById('transaction-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                        className="text-sm text-sky-400 hover:text-sky-300 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-md px-2 py-1"
                       >
                         Add your first transaction →
                       </button>
@@ -757,7 +757,7 @@ export function TransactionsTab({
                           <button
                             type="button"
                             onClick={() => setSharingTransaction(transaction)}
-                            className="p-1.5 rounded-md bg-white/10 hover:bg-sky-500/20 text-slate-300 hover:text-sky-300 transition"
+                            className="p-1.5 rounded-md bg-white/10 hover:bg-sky-500/20 text-slate-300 hover:text-sky-300 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                             aria-label={
                               transaction.description ? `Share expense: ${transaction.description}` : 'Share expense'
                             }
@@ -768,7 +768,7 @@ export function TransactionsTab({
                         <button
                           type="button"
                           onClick={() => handleTransactionEdit(transaction)}
-                          className="p-1.5 rounded-md bg-white/10 hover:bg-white/20 text-slate-300 hover:text-white transition"
+                          className="p-1.5 rounded-md bg-white/10 hover:bg-white/20 text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                           title="Edit"
                           aria-label={`Edit ${transaction.description || 'transaction'}`}
                         >
@@ -777,7 +777,7 @@ export function TransactionsTab({
                         <button
                           type="button"
                           onClick={() => handleTransactionDelete(transaction.id)}
-                          className="p-1.5 rounded-md bg-white/10 hover:bg-rose-500/30 text-slate-300 hover:text-rose-400 transition"
+                          className="p-1.5 rounded-md bg-white/10 hover:bg-rose-500/30 text-slate-300 hover:text-rose-400 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                           title="Delete"
                           aria-label={`Delete ${transaction.description || 'transaction'}`}
                         >


### PR DESCRIPTION
Added standard Tailwind `focus-visible` classes to scattered raw `<button>` elements that were bypassing the central `<Button>` component and lacking clear keyboard focus states.

**💡 What:** Added explicit `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950` styles to raw buttons across the Dashboard, Budgets, Categories, Transactions, and Holdings tabs.
**🎯 Why:** Users navigating via keyboard could not reliably see which action button had focus, leading to a frustrating and inaccessible experience.
**♿ Accessibility:** Greatly improved keyboard tab-navigation clarity, ensuring focus outlines conform to standard WCAG guidelines.

A journal entry has been added noting the importance of ensuring these utility classes are applied whenever raw `<button>` elements are used instead of the standardized `Button` UI component.

---
*PR created automatically by Jules for task [3519852819946278368](https://jules.google.com/task/3519852819946278368) started by @avifenesh*