### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak random number generation

### DIFF
--- a/src/components/ai/chat-utils.ts
+++ b/src/components/ai/chat-utils.ts
@@ -23,8 +23,21 @@ export function createTitleFromMessage(message: Message | undefined): string | n
 }
 
 export function createSession(title: string, isCustomTitle = false): ChatSession {
+  let id: string
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    id = `session-${crypto.randomUUID()}`
+  } else {
+    const fallback =
+      typeof crypto !== 'undefined' && crypto.getRandomValues
+        ? Array.from(crypto.getRandomValues(new Uint8Array(4)))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('')
+        : Math.random().toString(36).slice(2, 10)
+    id = `session-${Date.now()}-${fallback}`
+  }
+
   return {
-    id: crypto.randomUUID?.() ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    id,
     title,
     messages: [],
     createdAt: new Date().toISOString(),
@@ -55,7 +68,16 @@ export function loadSessionsFromStorage(storageKey: string): ChatSession[] {
 }
 
 export function generateMessageId(): string {
-  return crypto.randomUUID?.() ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return `msg-${crypto.randomUUID()}`
+  }
+  const fallback =
+    typeof crypto !== 'undefined' && crypto.getRandomValues
+      ? Array.from(crypto.getRandomValues(new Uint8Array(4)))
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('')
+      : Math.random().toString(36).slice(2, 10)
+  return `msg-${Date.now()}-${fallback}`
 }
 
 export const quickPrompts = [


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Weak and predictable random number generation (`Math.random()`) used for chat session and message ID generation, combined with unsafe `crypto.randomUUID?.()` calls that could throw ReferenceErrors in strictly defined environments.
🎯 Impact: Predictable IDs could potentially lead to session conflicts or predictable resource identifiers if attackers can reverse the PRNG state or guess generation times. Furthermore, the previous implementation risked runtime exceptions in certain environments.
🔧 Fix: Updated ID generation to verify `typeof crypto !== 'undefined'` and safely fallback to `crypto.getRandomValues()` to construct secure random sequences before finally falling back to `Math.random()` as a last resort, fully retaining necessary `session-` and `msg-` string prefixes.
✅ Verification: Ran full `pnpm test` suite to ensure functionality remains unchanged, and verified type safety via `pnpm check-types`. Evaluated under the strict 50-line boundary limit while avoiding "security theater" by reverting unnecessary ID modifications on ephemeral/temporary local UI variables.

---
*PR created automatically by Jules for task [2940740670093800706](https://jules.google.com/task/2940740670093800706) started by @avifenesh*