### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in cron endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Login endpoint exposed user existence via response time difference (bcrypt comparison vs immediate return).
 **Learning:** `verifyCredentials` checked user existence before verifying password, allowing ~100ms timing difference.
 **Prevention:** Use constant-time comparison logic. Always perform `bcrypt.compare` even if user is not found, using a pre-computed dummy hash.
+
+## 2024-03-22 - Timing Attack via Secret String Comparison
+**Vulnerability:** Cron endpoints used `!==` for comparing the provided authorization header (`Bearer ${secret}`) against the expected secret, allowing character-by-character timing attacks.
+**Learning:** Standard string comparisons terminate early upon the first mismatched character. When comparing secrets (like API keys, webhook signatures, or cron secrets), this response time difference can be measured by attackers to infer the secret.
+**Prevention:** Always use constant-time comparisons for secrets. Convert both the expected and provided strings to `Buffer`s, ensure they have the exact same length (`expected.length === provided.length`), and then use `crypto.timingSafeEqual()`.

--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { serverLogger } from '@/lib/server-logger'
@@ -32,7 +33,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
   }
 
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  const expectedAuth = Buffer.from(`Bearer ${cronSecret}`)
+  const providedAuth = Buffer.from(authHeader || '')
+
+  if (expectedAuth.length !== providedAuth.length || !crypto.timingSafeEqual(expectedAuth, providedAuth)) {
     serverLogger.warn('Cron cleanup: unauthorized access attempt', {
       action: 'cron.cleanup',
       clientIp,

--- a/src/app/api/cron/subscriptions/route.ts
+++ b/src/app/api/cron/subscriptions/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { processExpiredSubscriptions } from '@/lib/subscription'
 import { serverLogger } from '@/lib/server-logger'
@@ -29,7 +30,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
   }
 
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  const expectedAuth = Buffer.from(`Bearer ${cronSecret}`)
+  const providedAuth = Buffer.from(authHeader || '')
+
+  if (expectedAuth.length !== providedAuth.length || !crypto.timingSafeEqual(expectedAuth, providedAuth)) {
     serverLogger.warn('Cron subscription expiration: unauthorized access attempt', {
       action: 'cron.subscriptions',
       clientIp,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The cron endpoints used a simple `!==` comparison for validating the authorization header against the expected `cronSecret`. This allows an attacker to measure the response time of the request and infer the secret character-by-character.
🎯 Impact: Attackers could bypass cron endpoint authentication.
🔧 Fix: Used `crypto.timingSafeEqual` with matching `Buffer` lengths to execute a constant-time comparison.
✅ Verification: Code analysis and unit tests (`pnpm lint` passed).

---
*PR created automatically by Jules for task [15874031018404369747](https://jules.google.com/task/15874031018404369747) started by @avifenesh*