### PR TITLE
🎨 Palette: Improve keyboard focus states for transaction buttons

### DIFF
--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -692,7 +692,7 @@ export function TransactionsTab({
                             .getElementById('transaction-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                       >
                         Add your first transaction →
                       </button>
@@ -757,7 +757,7 @@ export function TransactionsTab({
                           <button
                             type="button"
                             onClick={() => setSharingTransaction(transaction)}
-                            className="p-1.5 rounded-md bg-white/10 hover:bg-sky-500/20 text-slate-300 hover:text-sky-300 transition"
+                            className="p-1.5 rounded-md bg-white/10 hover:bg-sky-500/20 text-slate-300 hover:text-sky-300 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                             aria-label={
                               transaction.description ? `Share expense: ${transaction.description}` : 'Share expense'
                             }
@@ -768,7 +768,7 @@ export function TransactionsTab({
                         <button
                           type="button"
                           onClick={() => handleTransactionEdit(transaction)}
-                          className="p-1.5 rounded-md bg-white/10 hover:bg-white/20 text-slate-300 hover:text-white transition"
+                          className="p-1.5 rounded-md bg-white/10 hover:bg-white/20 text-slate-300 hover:text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                           title="Edit"
                           aria-label={`Edit ${transaction.description || 'transaction'}`}
                         >
@@ -777,7 +777,7 @@ export function TransactionsTab({
                         <button
                           type="button"
                           onClick={() => handleTransactionDelete(transaction.id)}
-                          className="p-1.5 rounded-md bg-white/10 hover:bg-rose-500/30 text-slate-300 hover:text-rose-400 transition"
+                          className="p-1.5 rounded-md bg-white/10 hover:bg-rose-500/30 text-slate-300 hover:text-rose-400 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                           title="Delete"
                           aria-label={`Delete ${transaction.description || 'transaction'}`}
                         >

--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -692,7 +692,7 @@ export function TransactionsTab({
                             .getElementById('transaction-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -mx-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                       >
                         Add your first transaction →
                       </button>
@@ -759,6 +759,9 @@ export function TransactionsTab({
                             onClick={() => setSharingTransaction(transaction)}
                             className="p-1.5 rounded-md bg-white/10 hover:bg-sky-500/20 text-slate-300 hover:text-sky-300 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                             aria-label={
+                              transaction.description ? `Share expense: ${transaction.description}` : 'Share expense'
+                            }
+                            title={
                               transaction.description ? `Share expense: ${transaction.description}` : 'Share expense'
                             }
                           >


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind classes to the transaction list action buttons (Share, Edit, Delete) and the empty state button. Also added padding and negative margins to the inline text button so the focus ring doesn't clip the text.
🎯 Why: To improve keyboard accessibility and provide clear visual feedback when interacting with transaction buttons via keyboard navigation, aligning with the existing design system focus states.
♿ Accessibility: Ensures that keyboard users can clearly see which interactive element currently has focus. Added to purely visual interaction patterns without needing custom CSS.

---
*PR created automatically by Jules for task [15047112228568165574](https://jules.google.com/task/15047112228568165574) started by @avifenesh*