### PR TITLE
🎨 Palette: Add keyboard focus styles to text buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing focus styles on interactive text buttons
+**Learning:** Found multiple instances where inline text buttons (e.g., "Add your first transaction →", "Delete") lack visible focus states. This means keyboard users cannot see when these elements are focused, breaking accessibility.
+**Action:** Always add explicit focus-visible styles to custom buttons. Use Tailwind classes like `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950` to match existing focus patterns in the app. Note: for inline text buttons, adding some padding and negative margin (e.g., `rounded-md px-2 py-1 -ml-2`) helps the focus ring not hug the text too tightly without disrupting layout.

--- a/src/components/dashboard/holdings-tab.tsx
+++ b/src/components/dashboard/holdings-tab.tsx
@@ -332,7 +332,7 @@ export default function HoldingsTab({
                     ?.closest('form')
                     ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                 }
-                className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
                 Add your first holding →
               </button>
@@ -369,7 +369,7 @@ export default function HoldingsTab({
                     onClick={() => handleDeleteRequest(holding.id, holding.symbol)}
                     disabled={isPendingAction || deletingId === holding.id}
                     className={cn(
-                      'text-xs text-rose-400 transition hover:text-rose-300',
+                      'text-xs text-rose-400 transition hover:text-rose-300 rounded-md px-2 py-1 -mr-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
                       (isPendingAction || deletingId === holding.id) && 'opacity-50 cursor-not-allowed',
                     )}
                   >

--- a/src/components/dashboard/holdings-tab.tsx
+++ b/src/components/dashboard/holdings-tab.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/utils/cn'
+import { textButtonFocusClasses, focusRingClasses } from '@/utils/focus-styles'
 import { formatCurrency } from '@/utils/format'
 import { useCsrfToken } from '@/hooks/useCsrfToken'
 
@@ -332,7 +333,11 @@ export default function HoldingsTab({
                     ?.closest('form')
                     ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                 }
-                className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                className={cn(
+                  'text-sm text-sky-400 hover:text-sky-300 font-medium -ml-2',
+                  textButtonFocusClasses,
+                  focusRingClasses,
+                )}
               >
                 Add your first holding →
               </button>
@@ -369,7 +374,11 @@ export default function HoldingsTab({
                     onClick={() => handleDeleteRequest(holding.id, holding.symbol)}
                     disabled={isPendingAction || deletingId === holding.id}
                     className={cn(
-                      'text-xs text-rose-400 transition hover:text-rose-300 rounded-md px-2 py-1 -mr-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
+                      cn(
+                        'text-xs text-rose-400 transition hover:text-rose-300 -mr-2',
+                        textButtonFocusClasses,
+                        focusRingClasses,
+                      ),
                       (isPendingAction || deletingId === holding.id) && 'opacity-50 cursor-not-allowed',
                     )}
                   >

--- a/src/components/dashboard/tabs/budgets-tab.tsx
+++ b/src/components/dashboard/tabs/budgets-tab.tsx
@@ -312,7 +312,7 @@ export function BudgetsTab({
                       onClick={() =>
                         document.getElementById('budget-form')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                       }
-                      className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                      className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                     >
                       Add your first budget →
                     </button>

--- a/src/components/dashboard/tabs/budgets-tab.tsx
+++ b/src/components/dashboard/tabs/budgets-tab.tsx
@@ -14,6 +14,7 @@ import { filterBudgets, getBudgetProgress, getBudgetTotals } from '@/lib/dashboa
 import { createAccountOptions } from '@/lib/select-options'
 import { formatCurrency } from '@/utils/format'
 import { cn } from '@/utils/cn'
+import { textButtonFocusClasses, focusRingClasses } from '@/utils/focus-styles'
 import { toast } from '@/hooks/useToast'
 import { useCsrfToken } from '@/hooks/useCsrfToken'
 import { useFormValidation, validators } from '@/hooks/useFormValidation'
@@ -312,7 +313,11 @@ export function BudgetsTab({
                       onClick={() =>
                         document.getElementById('budget-form')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                       }
-                      className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                      className={cn(
+                        'text-sm text-sky-400 hover:text-sky-300 font-medium -ml-2',
+                        textButtonFocusClasses,
+                        focusRingClasses,
+                      )}
                     >
                       Add your first budget →
                     </button>

--- a/src/components/dashboard/tabs/categories-tab.tsx
+++ b/src/components/dashboard/tabs/categories-tab.tsx
@@ -13,6 +13,8 @@ import { filterCategories } from '@/lib/dashboard-ux'
 import { toast } from '@/hooks/useToast'
 import { useCsrfToken } from '@/hooks/useCsrfToken'
 import { DashboardCategory, transactionTypeOptions, typeFilterOptions, TypeFilterValue } from './types'
+import { cn } from '@/utils/cn'
+import { textButtonFocusClasses, focusRingClasses } from '@/utils/focus-styles'
 
 type FormErrors = Partial<Record<string, string[]>>
 
@@ -240,7 +242,11 @@ export function CategoriesTab({ categories }: CategoriesTabProps) {
                           .getElementById('category-form')
                           ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                       }
-                      className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                      className={cn(
+                        'text-sm text-sky-400 hover:text-sky-300 font-medium -ml-2',
+                        textButtonFocusClasses,
+                        focusRingClasses,
+                      )}
                     >
                       Add your first category →
                     </button>

--- a/src/components/dashboard/tabs/categories-tab.tsx
+++ b/src/components/dashboard/tabs/categories-tab.tsx
@@ -240,7 +240,7 @@ export function CategoriesTab({ categories }: CategoriesTabProps) {
                           .getElementById('category-form')
                           ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                       }
-                      className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                      className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                     >
                       Add your first category →
                     </button>

--- a/src/components/dashboard/tabs/recurring-tab.tsx
+++ b/src/components/dashboard/tabs/recurring-tab.tsx
@@ -18,6 +18,7 @@ import { createAccountOptions } from '@/lib/select-options'
 import { RecurringTemplateSummary } from '@/lib/finance'
 import { formatCurrency } from '@/utils/format'
 import { cn } from '@/utils/cn'
+import { textButtonFocusClasses, focusRingClasses } from '@/utils/focus-styles'
 import { toast } from '@/hooks/useToast'
 import { useCsrfToken } from '@/hooks/useCsrfToken'
 import {
@@ -372,7 +373,11 @@ export function RecurringTab({
                             .getElementById('recurring-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                        className={cn(
+                          'text-sm text-sky-400 hover:text-sky-300 font-medium -ml-2',
+                          textButtonFocusClasses,
+                          focusRingClasses,
+                        )}
                       >
                         Add your first template →
                       </button>

--- a/src/components/dashboard/tabs/recurring-tab.tsx
+++ b/src/components/dashboard/tabs/recurring-tab.tsx
@@ -372,7 +372,7 @@ export function RecurringTab({
                             .getElementById('recurring-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                       >
                         Add your first template →
                       </button>

--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -692,7 +692,7 @@ export function TransactionsTab({
                             .getElementById('transaction-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium"
+                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                       >
                         Add your first transaction →
                       </button>

--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -17,6 +17,7 @@ import { createAccountOptions } from '@/lib/select-options'
 import { formatRelativeAmount } from '@/utils/format'
 import { normalizeDateInput } from '@/utils/date'
 import { cn } from '@/utils/cn'
+import { textButtonFocusClasses, focusRingClasses } from '@/utils/focus-styles'
 import { RequestList } from '@/components/dashboard/request-list'
 import { ShareExpenseForm } from '@/components/dashboard/share-expense-form'
 import { toast } from '@/hooks/useToast'
@@ -692,7 +693,11 @@ export function TransactionsTab({
                             .getElementById('transaction-form')
                             ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
                         }
-                        className="text-sm text-sky-400 hover:text-sky-300 font-medium rounded-md px-2 py-1 -ml-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                        className={cn(
+                          'text-sm text-sky-400 hover:text-sky-300 font-medium -ml-2',
+                          textButtonFocusClasses,
+                          focusRingClasses,
+                        )}
                       >
                         Add your first transaction →
                       </button>

--- a/src/utils/focus-styles.ts
+++ b/src/utils/focus-styles.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared focus-visible styles for interactive text buttons.
+ *
+ * These classes ensure consistent keyboard navigation and focus indicators
+ * across the application.
+ */
+
+/**
+ * Focus ring styles for keyboard navigation.
+ * Use this with interactive elements that need visible focus indicators.
+ */
+export const focusRingClasses =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950'
+
+/**
+ * Complete text button focus styles including padding and rounding.
+ * Combines focus ring with base button styling for inline text buttons.
+ */
+export const textButtonFocusClasses = 'rounded-md px-2 py-1'


### PR DESCRIPTION
💡 What: Added explicit `focus-visible` styles to multiple interactive text-only buttons across the dashboard tabs (e.g., "Add your first transaction →", "Delete" buttons).

🎯 Why: Keyboard users had no visual indicator that these buttons were focused, making navigation difficult and non-accessible. This ensures standard focus rings are applied consistently.

📸 Before/After: Visual tests verify a standard `ring-2` focus style applies when using keyboard navigation without disturbing layout.

♿ Accessibility: Ensures interactive buttons provide explicit visible focus states, addressing a WCAG compliance gap.

---
*PR created automatically by Jules for task [3718703320670430290](https://jules.google.com/task/3718703320670430290) started by @avifenesh*