### PR TITLE
fix(security): hash password reset tokens before storage

### DIFF
--- a/src/app/api/v1/auth/request-reset/route.ts
+++ b/src/app/api/v1/auth/request-reset/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { randomBytes } from 'crypto'
+import { randomBytes, createHash } from 'crypto'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { consumeRateLimit } from '@/lib/rate-limit'
@@ -48,11 +48,14 @@ export async function POST(request: NextRequest) {
     const resetToken = randomBytes(32).toString('hex')
     const resetExpires = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
 
-    // Update user with reset token
+    // Hash token before storing (security best practice - prevents token theft if DB is compromised)
+    const hashedToken = createHash('sha256').update(resetToken).digest('hex')
+
+    // Update user with hashed reset token
     await prisma.user.update({
       where: { id: user.id },
       data: {
-        passwordResetToken: resetToken,
+        passwordResetToken: hashedToken,
         passwordResetExpires: resetExpires,
       },
     })

--- a/src/app/api/v1/auth/reset-password/route.ts
+++ b/src/app/api/v1/auth/reset-password/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { createHash } from 'crypto'
 import bcrypt from 'bcryptjs'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
@@ -32,9 +33,12 @@ export async function POST(request: NextRequest) {
 
     const { token, newPassword } = parsed.data
 
-    // Find user with this reset token
+    // Hash incoming token to compare with stored hash
+    const hashedToken = createHash('sha256').update(token).digest('hex')
+
+    // Find user with this hashed reset token
     const user = await prisma.user.findUnique({
-      where: { passwordResetToken: token },
+      where: { passwordResetToken: hashedToken },
     })
 
     if (!user) {


### PR DESCRIPTION
## Summary
- Hash reset tokens with SHA-256 before storing in database
- Update reset-password API to hash incoming tokens before lookup
- Matches secure pattern already used in server actions

## Security Fix
This addresses a critical security vulnerability where password reset tokens were stored in plaintext in the database via the API endpoints. If the database were compromised, attackers could use these tokens to reset any user's password.

The server action (`src/app/actions/auth.ts`) already implemented this correctly - the API endpoints now follow the same secure pattern:
1. Generate random token
2. Hash token with SHA-256 before storage
3. Send plaintext token via email
4. Hash incoming token before database lookup

## Test Plan
- [x] All 16 password reset unit tests pass
- [x] TypeScript type checks pass
- [x] ESLint passes

## References
- Secure pattern reference: `src/app/actions/auth.ts` lines 98-99 (token hashing on storage) and lines 150-151 (token hashing on lookup)