### PR TITLE
🎨 Palette: Add type='search' to filter inputs

### DIFF
--- a/src/components/dashboard/tabs/categories-tab.tsx
+++ b/src/components/dashboard/tabs/categories-tab.tsx
@@ -200,6 +200,7 @@ export function CategoriesTab({ categories }: CategoriesTabProps) {
                 </label>
                 <Input
                   id="category-filter-search"
+                  type="search"
                   value={categorySearch}
                   onChange={(event) => {
                     setCategorySearch(event.target.value)

--- a/src/components/dashboard/tabs/transactions-tab.tsx
+++ b/src/components/dashboard/tabs/transactions-tab.tsx
@@ -655,6 +655,7 @@ export function TransactionsTab({
                 </label>
                 <Input
                   id="transaction-filter-search"
+                  type="search"
                   value={transactionSearch}
                   onChange={(event) => setTransactionSearch(event.target.value)}
                   placeholder="description, category"


### PR DESCRIPTION
💡 What: Added `type="search"` to the `<Input>` components used for filtering in the Categories and Transactions dashboard tabs.

🎯 Why: The previous implementation used the default `type="text"`. By updating this to `type="search"`, we leverage native browser functionality, specifically the built-in "clear" (x) button that appears when text is entered, allowing users to quickly reset their filters without needing custom JavaScript or extra UI elements. It also prompts mobile devices to display a search-optimized keyboard (e.g., showing a "Search" button instead of "Return").

📸 Before/After: See attached screenshot for verification of the native clear button rendering within the styled input component.

♿ Accessibility: This change improves semantic HTML structure, making the inputs' purpose clearer to assistive technologies.

---
*PR created automatically by Jules for task [3680245743186736300](https://jules.google.com/task/3680245743186736300) started by @avifenesh*